### PR TITLE
PFP-8907

### DIFF
--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/BehandlingFeil.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/BehandlingFeil.java
@@ -2,6 +2,8 @@ package no.nav.foreldrepenger.tilbakekreving.behandling;
 
 import static no.nav.vedtak.feil.LogLevel.WARN;
 
+import java.util.UUID;
+
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.Saksnummer;
 import no.nav.vedtak.feil.Feil;
 import no.nav.vedtak.feil.FeilFactory;
@@ -36,5 +38,8 @@ public interface BehandlingFeil extends DeklarerteFeil {
 
     @FunksjonellFeil(feilkode = "FPT-663486", feilmelding = "saksnummer %s oppfyller ikke kravene for tilbakekreving", løsningsforslag = "", logLevel = LogLevel.WARN)
     Feil kanIkkeOppretteTilbakekrevingBehandling(Saksnummer saksnummer);
+
+    @FunksjonellFeil(feilkode = "FPT-663488", feilmelding = "tilbakekreving finnes allerede for eksternUuid %s ", løsningsforslag = "", logLevel = LogLevel.WARN)
+    Feil kanIkkeOppretteTilbakekrevingBehandling(UUID eksternUuid);
 
 }

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/BehandlingTjeneste.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/BehandlingTjeneste.java
@@ -34,4 +34,6 @@ public interface BehandlingTjeneste {
 
     boolean erBehandlingHenlagt(Behandling behandling);
 
+    boolean kanOppretteBehandling(Saksnummer saksnummer, UUID eksternUuid);
+
 }

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/KanBehandlingOpprettesDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/KanBehandlingOpprettesDto.java
@@ -1,0 +1,23 @@
+package no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto;
+
+public class KanBehandlingOpprettesDto {
+
+    private boolean kanBehandlingOpprettes;
+    private boolean kanRevurderingOpprettes;
+
+    public boolean isKanBehandlingOpprettes() {
+        return kanBehandlingOpprettes;
+    }
+
+    public void setKanBehandlingOpprettes(boolean kanBehandlingOpprettes) {
+        this.kanBehandlingOpprettes = kanBehandlingOpprettes;
+    }
+
+    public boolean isKanRevurderingOpprettes() {
+        return kanRevurderingOpprettes;
+    }
+
+    public void setKanRevurderingOpprettes(boolean kanRevurderingOpprettes) {
+        this.kanRevurderingOpprettes = kanRevurderingOpprettes;
+    }
+}

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -12,7 +14,6 @@ import java.util.UUID;
 import javax.ws.rs.core.Response;
 
 import org.apache.http.HttpStatus;
-import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,6 +30,7 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandli
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.ekstern.EksternBehandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.geografisk.Språkkode;
@@ -36,8 +38,12 @@ import no.nav.foreldrepenger.tilbakekreving.domene.typer.AktørId;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.aksjonspunkt.BehandlingsprosessApplikasjonTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto.BehandlingDtoTjeneste;
+import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto.BehandlingIdDto;
 import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto.HenleggBehandlingDto;
+import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto.KanBehandlingOpprettesDto;
 import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto.OpprettBehandlingDto;
+import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto.UuidDto;
+import no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.felles.dto.SaksnummerDto;
 
 public class BehandlingRestTjenesteTest {
 
@@ -58,11 +64,15 @@ public class BehandlingRestTjenesteTest {
     private BehandlingRevurderingTjeneste revurderingTjenesteMock = mock(BehandlingRevurderingTjeneste.class);
     private BehandlingskontrollAsynkTjeneste behandlingskontrollAsynkTjenesteMock = mock(BehandlingskontrollAsynkTjeneste.class);
     private BehandlendeEnhetTjeneste behandlendeEnhetTjenesteMock = mock(BehandlendeEnhetTjeneste.class);
-    private BehandlingsTjenesteProvider behandlingsTjenesteProvider = new BehandlingsTjenesteProvider(behandlingTjenesteMock,gjenopptaBehandlingTjenesteMock,
-        henleggBehandlingTjenesteMock,revurderingTjenesteMock,behandlendeEnhetTjenesteMock);
+    private BehandlingsTjenesteProvider behandlingsTjenesteProvider = new BehandlingsTjenesteProvider(behandlingTjenesteMock, gjenopptaBehandlingTjenesteMock,
+        henleggBehandlingTjenesteMock, revurderingTjenesteMock, behandlendeEnhetTjenesteMock);
 
     private BehandlingRestTjeneste behandlingRestTjeneste = new BehandlingRestTjeneste(behandlingsTjenesteProvider, behandlingDtoTjenesteMock,
         behandlingsprosessTjeneste, behandlingskontrollAsynkTjenesteMock);
+
+    private static SaksnummerDto saksnummerDto = new SaksnummerDto(GYLDIG_SAKSNR);
+    private static UuidDto uuidDto = new UuidDto(EKSTERN_BEHANDLING_UUID);
+    private static BehandlingIdDto behandlingIdDto = new BehandlingIdDto(1l);
 
     @Test
     public void test_opprett_behandling_skal_feile_med_ugyldig_saksnummer() throws URISyntaxException {
@@ -78,13 +88,13 @@ public class BehandlingRestTjenesteTest {
     public void test_skal_opprette_ny_behandling() throws URISyntaxException {
         behandlingRestTjeneste.opprettBehandling(opprettBehandlingDto(GYLDIG_SAKSNR, EKSTERN_BEHANDLING_UUID, FP_YTELSE_TYPE));
 
-        verify(behandlingTjenesteMock).opprettBehandlingManuell(any(Saksnummer.class), any(UUID.class),any(FagsakYtelseType.class), any(BehandlingType.class));
+        verify(behandlingTjenesteMock).opprettBehandlingManuell(any(Saksnummer.class), any(UUID.class), any(FagsakYtelseType.class), any(BehandlingType.class));
     }
 
     @Test
     public void test_skal_opprette_ny_behandling_for_revurdering() throws URISyntaxException {
         when(behandlingskontrollAsynkTjenesteMock.asynkProsesserBehandling(any(Behandling.class))).thenReturn("1");
-        when(revurderingTjenesteMock.opprettRevurdering(any(Saksnummer.class), any(UUID.class), any(BehandlingÅrsakType.class),any(BehandlingType.class)))
+        when(revurderingTjenesteMock.opprettRevurdering(any(Saksnummer.class), any(UUID.class), any(BehandlingÅrsakType.class), any(BehandlingType.class)))
             .thenReturn(mockBehandling());
 
         OpprettBehandlingDto opprettBehandlingDto = opprettBehandlingDto(GYLDIG_SAKSNR, EKSTERN_BEHANDLING_UUID, FP_YTELSE_TYPE);
@@ -93,8 +103,8 @@ public class BehandlingRestTjenesteTest {
 
         Response response = behandlingRestTjeneste.opprettBehandling(opprettBehandlingDto);
 
-        verify(revurderingTjenesteMock, atLeastOnce()).opprettRevurdering(any(Saksnummer.class), any(UUID.class), any(BehandlingÅrsakType.class),any(BehandlingType.class));
-        Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_ACCEPTED);
+        verify(revurderingTjenesteMock, atLeastOnce()).opprettRevurdering(any(Saksnummer.class), any(UUID.class), any(BehandlingÅrsakType.class), any(BehandlingType.class));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_ACCEPTED);
     }
 
     @Test
@@ -106,6 +116,43 @@ public class BehandlingRestTjenesteTest {
         behandlingRestTjeneste.henleggBehandling(opprettHenleggBehandlingDto(1234l, versjon, årsak, begrunnelse));
 
         verify(henleggBehandlingTjenesteMock).henleggBehandling(1234l, årsak, begrunnelse);
+    }
+
+    @Test
+    public void test_kan_behandling_opprettes_med_tilbakekreving() {
+        when(behandlingTjenesteMock.kanOppretteBehandling(any(Saksnummer.class), any(UUID.class))).thenReturn(true);
+
+        Response response = behandlingRestTjeneste.kanOpprettesBehandling(saksnummerDto, uuidDto, null);
+        assertThat(response.getEntity()).isNotNull();
+        KanBehandlingOpprettesDto kanBehandlingOpprettesDto = (KanBehandlingOpprettesDto) response.getEntity();
+        assertThat(kanBehandlingOpprettesDto.isKanBehandlingOpprettes()).isTrue();
+        assertThat(kanBehandlingOpprettesDto.isKanRevurderingOpprettes()).isFalse();
+    }
+
+    @Test
+    public void test_kan_behandling_opprettes_med_revurdering() {
+        when(behandlingTjenesteMock.kanOppretteBehandling(any(Saksnummer.class), any(UUID.class))).thenReturn(false);
+        when(revurderingTjenesteMock.hentEksternBehandling(anyLong())).thenReturn(opprettEksternBehandling());
+        when(revurderingTjenesteMock.kanOppretteRevurdering(any(UUID.class))).thenReturn(true);
+
+        Response response = behandlingRestTjeneste.kanOpprettesBehandling(saksnummerDto, uuidDto, behandlingIdDto);
+        assertThat(response.getEntity()).isNotNull();
+        KanBehandlingOpprettesDto kanBehandlingOpprettesDto = (KanBehandlingOpprettesDto) response.getEntity();
+        assertThat(kanBehandlingOpprettesDto.isKanBehandlingOpprettes()).isFalse();
+        assertThat(kanBehandlingOpprettesDto.isKanRevurderingOpprettes()).isTrue();
+    }
+
+    @Test
+    public void test_kan_behandling_opprettes_med_tilbakekreving_og_revurdering() {
+        when(behandlingTjenesteMock.kanOppretteBehandling(any(Saksnummer.class), any(UUID.class))).thenReturn(true);
+        when(revurderingTjenesteMock.hentEksternBehandling(anyLong())).thenReturn(opprettEksternBehandling());
+        when(revurderingTjenesteMock.kanOppretteRevurdering(any(UUID.class))).thenReturn(true);
+
+        Response response = behandlingRestTjeneste.kanOpprettesBehandling(saksnummerDto, uuidDto, behandlingIdDto);
+        assertThat(response.getEntity()).isNotNull();
+        KanBehandlingOpprettesDto kanBehandlingOpprettesDto = (KanBehandlingOpprettesDto) response.getEntity();
+        assertThat(kanBehandlingOpprettesDto.isKanBehandlingOpprettes()).isTrue();
+        assertThat(kanBehandlingOpprettesDto.isKanRevurderingOpprettes()).isTrue();
     }
 
     private OpprettBehandlingDto opprettBehandlingDto(String saksnr, String eksternUuid, FagsakYtelseType ytelseType) {
@@ -128,8 +175,12 @@ public class BehandlingRestTjenesteTest {
 
     private Behandling mockBehandling() {
         return Behandling.nyBehandlingFor(
-            Fagsak.opprettNy( new Saksnummer(GYLDIG_SAKSNR), NavBruker.opprettNy(new AktørId(GYLDIG_AKTØR_ID), Språkkode.nb)),
+            Fagsak.opprettNy(new Saksnummer(GYLDIG_SAKSNR), NavBruker.opprettNy(new AktørId(GYLDIG_AKTØR_ID), Språkkode.nb)),
             BehandlingType.REVURDERING_TILBAKEKREVING).build();
+    }
+
+    private EksternBehandling opprettEksternBehandling() {
+        return new EksternBehandling(mockBehandling(), 1l, UUID.fromString(EKSTERN_BEHANDLING_UUID));
     }
 
 }


### PR DESCRIPTION
endret /kan-opprettes for å sjekke mulighet for opprettBehandling og opprettRevurdering. La til en sjekk for å hindre opprettTilbakekreving hvis det finnes allerede en avsluttet tilbakekreving for samme fpsak revurdering