### PR TITLE
PFP-9167

### DIFF
--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingRevurderingTjenesteTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingRevurderingTjenesteTest.java
@@ -29,15 +29,7 @@ public class BehandlingRevurderingTjenesteTest extends FellesTestOppsett {
         expectedException.expect(FunksjonellException.class);
         expectedException.expectMessage("FPT-663487");
 
-        revurderingTjeneste.opprettRevurdering(saksnummer, eksternBehandlingUuid, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR, REVURDERING_BEHANDLING_TYPE);
-    }
-
-    @Test
-    public void opprettRevurdering_nårSaksnummerErUgyldig() {
-        expectedException.expect(TekniskException.class);
-        expectedException.expectMessage("FPT-429884");
-
-        revurderingTjeneste.opprettRevurdering(null, eksternBehandlingUuid, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR, REVURDERING_BEHANDLING_TYPE);
+        revurderingTjeneste.opprettRevurdering(behandling.getId(), BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR);
     }
 
     @Test
@@ -46,7 +38,7 @@ public class BehandlingRevurderingTjenesteTest extends FellesTestOppsett {
         BehandlingLås behandlingLås = repoProvider.getBehandlingRepository().taSkriveLås(behandling);
         behandlingRepository.lagre(behandling, behandlingLås);
 
-        Behandling revurdering = revurderingTjeneste.opprettRevurdering(saksnummer, eksternBehandlingUuid, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR, REVURDERING_BEHANDLING_TYPE);
+        Behandling revurdering = revurderingTjeneste.opprettRevurdering(behandling.getId(), BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR);
         assertThat(revurdering).isNotNull();
         assertThat(revurdering.getFagsakId()).isNotNull();
         assertThat(revurdering.getStatus()).isEqualByComparingTo(BehandlingStatus.OPPRETTET);

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteImplTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteImplTest.java
@@ -73,7 +73,7 @@ public class BehandlingTjenesteImplTest extends FellesTestOppsett {
     public void skal_opprette_behandling_manell_med_allerede_åpen_revurdeing_behandling() {
         UUID eksternUUID = UUID.randomUUID();
         avsluttBehandling();
-        revurderingTjeneste.opprettRevurdering(saksnummer, eksternBehandlingUuid, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR, BehandlingType.REVURDERING_TILBAKEKREVING);
+        revurderingTjeneste.opprettRevurdering(behandling.getId(), BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR);
 
         Long behandlingId = behandlingTjeneste.opprettBehandlingManuell(saksnummer, eksternUUID, FagsakYtelseType.FORELDREPENGER, BehandlingType.TILBAKEKREVING);
         fellesBehandlingAssert(behandlingId, true);

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjeneste.java
@@ -128,7 +128,8 @@ public class BehandlingRestTjeneste {
             Long behandlingId = behandlingTjeneste.opprettBehandlingManuell(saksnummer, eksternUuid, opprettBehandlingDto.getFagsakYtelseType(), behandlingType);
             return Redirect.tilBehandlingPollStatus(behandlingId, Optional.empty());
         } else if (BehandlingType.REVURDERING_TILBAKEKREVING.equals(behandlingType)) {
-            Behandling revurdering = revurderingTjeneste.opprettRevurdering(saksnummer, eksternUuid, opprettBehandlingDto.getBehandlingArsakType(), behandlingType);
+            Long tbkBehandlingId = opprettBehandlingDto.getBehandlingId();
+            Behandling revurdering = revurderingTjeneste.opprettRevurdering(tbkBehandlingId, opprettBehandlingDto.getBehandlingArsakType());
             String gruppe = behandlingskontrollAsynkTjeneste.asynkProsesserBehandling(revurdering);
             return Redirect.tilBehandlingPollStatus(revurdering.getId(), Optional.of(gruppe));
         }

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/OpprettBehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/OpprettBehandlingDto.java
@@ -1,11 +1,5 @@
 package no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.behandling.dto;
 
-import java.util.UUID;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.NotNull;
-
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.FagsakYtelseType;
@@ -14,6 +8,13 @@ import no.nav.foreldrepenger.tilbakekreving.domene.typer.TilbakekrevingAbacAttri
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
 
 public class OpprettBehandlingDto implements AbacDto {
 
@@ -33,6 +34,11 @@ public class OpprettBehandlingDto implements AbacDto {
 
     @ValidKodeverk
     private FagsakYtelseType fagsakYtelseType;
+
+    //Gjelder kun for Tilbakekrevingsrevurdering
+    @Min(0)
+    @Max(Long.MAX_VALUE)
+    private Long behandlingId;
 
     public OpprettBehandlingDto() {
         // For CDI
@@ -78,11 +84,25 @@ public class OpprettBehandlingDto implements AbacDto {
         this.fagsakYtelseType = fagsakYtelseType;
     }
 
+    public Long getBehandlingId() {
+        return behandlingId;
+    }
+
+    public void setBehandlingId(Long behandlingId) {
+        this.behandlingId = behandlingId;
+    }
+
     @Override
     public AbacDataAttributter abacAttributter() {
-        return AbacDataAttributter.opprett()
-            .leggTil(StandardAbacAttributtType.SAKSNUMMER, saksnummer)
-            .leggTil(TilbakekrevingAbacAttributtType.FPSAK_BEHANDLING_UUID, eksternUuid);
+        if (getBehandlingType().equals(BehandlingType.TILBAKEKREVING)) {
+            return AbacDataAttributter.opprett()
+                .leggTil(StandardAbacAttributtType.SAKSNUMMER, saksnummer)
+                .leggTil(TilbakekrevingAbacAttributtType.FPSAK_BEHANDLING_UUID, eksternUuid);
+        } else if (getBehandlingType().equals(BehandlingType.REVURDERING_TILBAKEKREVING)) {
+            return AbacDataAttributter.opprett()
+                .leggTil(StandardAbacAttributtType.BEHANDLING_ID, getBehandlingId());
+        }
+        return AbacDataAttributter.opprett();
     }
 
 }

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
@@ -94,16 +94,17 @@ public class BehandlingRestTjenesteTest {
     @Test
     public void test_skal_opprette_ny_behandling_for_revurdering() throws URISyntaxException {
         when(behandlingskontrollAsynkTjenesteMock.asynkProsesserBehandling(any(Behandling.class))).thenReturn("1");
-        when(revurderingTjenesteMock.opprettRevurdering(any(Saksnummer.class), any(UUID.class), any(BehandlingÅrsakType.class), any(BehandlingType.class)))
+        when(revurderingTjenesteMock.opprettRevurdering(any(Long.class), any(BehandlingÅrsakType.class)))
             .thenReturn(mockBehandling());
 
         OpprettBehandlingDto opprettBehandlingDto = opprettBehandlingDto(GYLDIG_SAKSNR, EKSTERN_BEHANDLING_UUID, FP_YTELSE_TYPE);
         opprettBehandlingDto.setBehandlingType(BehandlingType.REVURDERING_TILBAKEKREVING);
         opprettBehandlingDto.setBehandlingArsakType(BehandlingÅrsakType.RE_OPPLYSNINGER_OM_VILKÅR);
+        opprettBehandlingDto.setBehandlingId(1l);
 
         Response response = behandlingRestTjeneste.opprettBehandling(opprettBehandlingDto);
 
-        verify(revurderingTjenesteMock, atLeastOnce()).opprettRevurdering(any(Saksnummer.class), any(UUID.class), any(BehandlingÅrsakType.class), any(BehandlingType.class));
+        verify(revurderingTjenesteMock, atLeastOnce()).opprettRevurdering(any(Long.class), any(BehandlingÅrsakType.class));
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_ACCEPTED);
     }
 


### PR DESCRIPTION
fikset problemer med opprett tilbakekreving revurdering. Nå er det mulig å opprette en tilbakekreving revurdering selv om fpsak revurdering ikke er gjeldende.