### PR TITLE
PFP-9399 Rydd ubrukte kolonner i EKSTERN_BEHANDLING og OKO_XML_MOTTATT

### DIFF
--- a/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_186__PFP-9399_fjern_ekstern_behandling.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_186__PFP-9399_fjern_ekstern_behandling.sql
@@ -1,0 +1,2 @@
+alter table EKSTERN_BEHANDLING drop column ekstern_id;
+alter table OKO_XML_MOTTATT drop column ekstern_behandling_id;


### PR DESCRIPTION
Hvis dere ønsker å sjekke at data er bevart, forsøk følgende SQL i prod:

select count(*) from ekstern_behandling where ekstern_id is not null and henvisning is null;
select count(*) from ekstern_behandling where ekstern_id != henvisning;
select count(*) from oko_xml_mottatt where ekstern_behandling_id is not null and henvisning is null;
select count(*) from oko_xml_mottatt where ekstern_behandling_id != henvisning;

Den siste spørringen returnerer ikke 0 rader. Her har henvisning-kolonnen blitt oppdatert etter migrering ble utført:

select id, ekstern_behandling_id, henvisning, endret_av, endret_tid from oko_xml_mottatt where ekstern_behandling_id != henvisning;
