### PR TITLE
PFP-9431

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/BehandlingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/BehandlingÅrsak.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -15,10 +16,6 @@ import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Version;
-
-import org.hibernate.annotations.JoinColumnOrFormula;
-import org.hibernate.annotations.JoinColumnsOrFormulas;
-import org.hibernate.annotations.JoinFormula;
 
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.BaseEntitet;
 
@@ -39,11 +36,8 @@ public class BehandlingÅrsak extends BaseEntitet {
     @JoinColumn(name = "behandling_id", nullable = false, updatable = false)
     private Behandling behandling;
 
-    @ManyToOne(optional = false)
-    @JoinColumnsOrFormulas({
-        @JoinColumnOrFormula(column = @JoinColumn(name = "behandling_arsak_type", referencedColumnName = "kode", nullable = false)),
-        @JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "kodeverk", value = "'" + BehandlingÅrsakType.DISCRIMINATOR
-            + "'"))})
+    @Convert(converter = BehandlingÅrsakType.KodeverdiConverter.class)
+    @Column(name="behandling_arsak_type",nullable = false)
     private BehandlingÅrsakType behandlingÅrsakType = BehandlingÅrsakType.UDEFINERT;
 
     @OneToOne

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/EksternBehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/EksternBehandlingÅrsakType.java
@@ -1,0 +1,24 @@
+package no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.kodeverk.Kodeliste;
+
+@Entity(name = "BehandlingÅrsakType")
+@DiscriminatorValue(EksternBehandlingÅrsakType.DISCRIMINATOR)
+public class EksternBehandlingÅrsakType extends Kodeliste {
+    public static final String DISCRIMINATOR = "BEHANDLING_AARSAK"; //$NON-NLS-1$
+
+    public static final EksternBehandlingÅrsakType UDEFINERT = new EksternBehandlingÅrsakType("-"); //$NON-NLS-1$
+
+    EksternBehandlingÅrsakType() {
+        //for Hibernate
+    }
+
+    private EksternBehandlingÅrsakType(String kode) {
+        super(kode, DISCRIMINATOR);
+    }
+
+
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/historikk/HistorikkInnslagTekstBuilder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/historikk/HistorikkInnslagTekstBuilder.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingResultatType;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.kodeverk.Kodeliste;
@@ -37,7 +39,9 @@ public class HistorikkInnslagTekstBuilder {
 
     public static final Map<String, Map<String, ? extends Kodeverdi>> KODEVERK_KODEVERDI_MAP = Map.ofEntries(
         new AbstractMap.SimpleEntry<>(Venteårsak.KODEVERK,Venteårsak.kodeMap()),
-        new AbstractMap.SimpleEntry<>(HistorikkBegrunnelseType.KODEVERK,HistorikkBegrunnelseType.kodeMap()));
+        new AbstractMap.SimpleEntry<>(HistorikkBegrunnelseType.KODEVERK,HistorikkBegrunnelseType.kodeMap()),
+        new AbstractMap.SimpleEntry<>(BehandlingÅrsakType.KODEVERK,BehandlingÅrsakType.kodeMap()),
+        new AbstractMap.SimpleEntry<>(BehandlingResultatType.KODEVERK, BehandlingResultatType.kodeMap()));
 
     public HistorikkInnslagTekstBuilder() {
         //

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.behandlingslager.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.behandlingslager.orm.xml
@@ -65,7 +65,7 @@
     <entity class="no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.personopplysning.SivilstandType"/>
     <entity class="no.nav.foreldrepenger.tilbakekreving.behandlingslager.geografisk.Språkkode"/>
     <entity class="no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.VurderÅrsak"/>
-    <entity class="no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType"/>
+    <entity class="no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.EksternBehandlingÅrsakType"/>
 
 
 </entity-mappings>

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/modell/BehandlingFeilutbetalingFakta.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/modell/BehandlingFeilutbetalingFakta.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.BehandlingsresultatDto;
-import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.BehandlingÅrsakDto;
+import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingÅrsakDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.TilbakekrevingValgDto;
 
 public class BehandlingFeilutbetalingFakta {
@@ -17,7 +17,7 @@ public class BehandlingFeilutbetalingFakta {
     private LocalDate totalPeriodeTom;
     private List<UtbetaltPeriode> perioder;
     private BehandlingsresultatDto behandlingsresultat;
-    private List<BehandlingÅrsakDto> behandlingÅrsaker;
+    private List<EksternBehandlingÅrsakDto> behandlingÅrsaker;
     private TilbakekrevingValgDto tilbakekrevingValg;
     private String begrunnelse;
 
@@ -53,7 +53,7 @@ public class BehandlingFeilutbetalingFakta {
         return behandlingsresultat;
     }
 
-    public List<BehandlingÅrsakDto> getBehandlingÅrsaker() {
+    public List<EksternBehandlingÅrsakDto> getBehandlingÅrsaker() {
         return behandlingÅrsaker;
     }
 
@@ -112,7 +112,7 @@ public class BehandlingFeilutbetalingFakta {
             return this;
         }
 
-        public Builder medBehandlingÅrsaker(List<BehandlingÅrsakDto> behandlingÅrsaker) {
+        public Builder medBehandlingÅrsaker(List<EksternBehandlingÅrsakDto> behandlingÅrsaker) {
             this.behandlingFeilutbetalingFakta.behandlingÅrsaker = behandlingÅrsaker;
             return this;
         }

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteImplTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteImplTest.java
@@ -25,6 +25,7 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandli
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.EksternBehandlingÅrsakType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.ekstern.EksternBehandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingLås;
@@ -40,8 +41,8 @@ import no.nav.foreldrepenger.tilbakekreving.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.Tillegsinformasjon;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.BehandlingsresultatDto;
-import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.BehandlingÅrsakDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingsinfoDto;
+import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingÅrsakDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.PersonopplysningDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SamletEksternBehandlingInfo;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.TilbakekrevingValgDto;
@@ -272,9 +273,9 @@ public class BehandlingTjenesteImplTest extends FellesTestOppsett {
         behandlingsresultatDto.setKonsekvenserForYtelsen(Lists.newArrayList(KonsekvensForYtelsen.ENDRING_I_BEREGNING, KonsekvensForYtelsen.FORELDREPENGER_OPPHØRER));
         eksternBehandlingsinfo.setBehandlingsresultat(behandlingsresultatDto);
 
-        BehandlingÅrsakDto behandlingÅrsakDto = new BehandlingÅrsakDto();
-        behandlingÅrsakDto.setBehandlingÅrsakType(BehandlingÅrsakType.RE_KLAGE_KA);
-        eksternBehandlingsinfo.setBehandlingÅrsaker(Lists.newArrayList(behandlingÅrsakDto));
+        EksternBehandlingÅrsakDto eksternBehandlingÅrsakDto = new EksternBehandlingÅrsakDto();
+        eksternBehandlingÅrsakDto.setBehandlingÅrsakType(EksternBehandlingÅrsakType.UDEFINERT);
+        eksternBehandlingsinfo.setBehandlingÅrsaker(Lists.newArrayList(eksternBehandlingÅrsakDto));
         return eksternBehandlingsinfo;
     }
 

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/FaktaFeilutbetalingTjenesteTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/FaktaFeilutbetalingTjenesteTest.java
@@ -15,15 +15,15 @@ import com.google.common.collect.Lists;
 import no.nav.foreldrepenger.tilbakekreving.FellesTestOppsett;
 import no.nav.foreldrepenger.tilbakekreving.behandling.modell.BehandlingFeilutbetalingFakta;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingResultatType;
-import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.EksternBehandlingÅrsakType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.ekstern.EksternBehandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.geografisk.Språkkode;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.tilbakekrevingsvalg.VidereBehandling;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.Tillegsinformasjon;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.BehandlingsresultatDto;
-import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.BehandlingÅrsakDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingsinfoDto;
+import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingÅrsakDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SamletEksternBehandlingInfo;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.TilbakekrevingValgDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.YtelsesbehandlingResultatType;
@@ -185,9 +185,9 @@ public class FaktaFeilutbetalingTjenesteTest extends FellesTestOppsett {
         behandlingsresultatDto.setKonsekvenserForYtelsen(Lists.newArrayList(KonsekvensForYtelsen.ENDRING_I_BEREGNING, KonsekvensForYtelsen.FORELDREPENGER_OPPHØRER));
         eksternBehandlingsinfo.setBehandlingsresultat(behandlingsresultatDto);
 
-        BehandlingÅrsakDto behandlingÅrsakDto = new BehandlingÅrsakDto();
-        behandlingÅrsakDto.setBehandlingÅrsakType(BehandlingÅrsakType.RE_KLAGE_KA);
-        eksternBehandlingsinfo.setBehandlingÅrsaker(Lists.newArrayList(behandlingÅrsakDto));
+        EksternBehandlingÅrsakDto eksternBehandlingÅrsakDto = new EksternBehandlingÅrsakDto();
+        eksternBehandlingÅrsakDto.setBehandlingÅrsakType(EksternBehandlingÅrsakType.UDEFINERT);
+        eksternBehandlingsinfo.setBehandlingÅrsaker(Lists.newArrayList(eksternBehandlingÅrsakDto));
         return eksternBehandlingsinfo;
     }
 

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/BehandlingÅrsakDto.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/BehandlingÅrsakDto.java
@@ -1,19 +1,10 @@
 package no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BehandlingÅrsakDto {
 
-    @JsonProperty("behandlingArsakType")
     private BehandlingÅrsakType behandlingÅrsakType;
-
-    public BehandlingÅrsakDto() {
-        // trengs for deserialisering av JSON
-    }
 
     public BehandlingÅrsakType getBehandlingÅrsakType() {
         return behandlingÅrsakType;

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/EksternBehandlingsinfoDto.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/EksternBehandlingsinfoDto.java
@@ -24,7 +24,7 @@ public class EksternBehandlingsinfoDto {
     private LocalDate vedtakDato;
     private BehandlingsresultatDto behandlingsresultat;
     @JsonProperty("behandlingArsaker")
-    private List<BehandlingÅrsakDto> behandlingÅrsaker = new ArrayList<>();
+    private List<EksternBehandlingÅrsakDto> behandlingÅrsaker = new ArrayList<>();
 
     public Henvisning getHenvisning() {
         return henvisning;
@@ -88,11 +88,11 @@ public class EksternBehandlingsinfoDto {
         this.behandlingsresultat = behandlingsresultat;
     }
 
-    public List<BehandlingÅrsakDto> getBehandlingÅrsaker() {
+    public List<EksternBehandlingÅrsakDto> getBehandlingÅrsaker() {
         return behandlingÅrsaker;
     }
 
-    public void setBehandlingÅrsaker(List<BehandlingÅrsakDto> behandlingÅrsaker) {
+    public void setBehandlingÅrsaker(List<EksternBehandlingÅrsakDto> behandlingÅrsaker) {
         this.behandlingÅrsaker = behandlingÅrsaker;
     }
 }

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/EksternBehandlingÅrsakDto.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/EksternBehandlingÅrsakDto.java
@@ -1,0 +1,25 @@
+package no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.EksternBehandlingÅrsakType;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EksternBehandlingÅrsakDto {
+
+    @JsonProperty("behandlingArsakType")
+    private EksternBehandlingÅrsakType behandlingÅrsakType;
+
+    public EksternBehandlingÅrsakDto() {
+        // trengs for deserialisering av JSON
+    }
+
+    public EksternBehandlingÅrsakType getBehandlingÅrsakType() {
+        return behandlingÅrsakType;
+    }
+
+    public void setBehandlingÅrsakType(EksternBehandlingÅrsakType behandlingÅrsakType) {
+        this.behandlingÅrsakType = behandlingÅrsakType;
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/OpprettBehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/OpprettBehandlingDto.java
@@ -30,7 +30,7 @@ public class OpprettBehandlingDto implements AbacDto {
     @ValidKodeverk
     private BehandlingType behandlingType;
 
-    @ValidKodeverk
+    @Valid
     private BehandlingÅrsakType behandlingArsakType;
 
     @Valid

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.EksternBehandlingÅrsakType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.ForeldelseVurderingType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.Venteårsak;
@@ -67,6 +68,7 @@ public class HentKodeverkTjeneste {
         map.put(BehandlingResultatType.class.getSimpleName(), BehandlingResultatType.kodeMap().values());
         map.put(VidereBehandling.class.getSimpleName(), VidereBehandling.kodeMap().values());
         map.put(VergeType.class.getSimpleName(), VergeType.kodeMap().values());
+        map.put(BehandlingÅrsakType.class.getSimpleName(), BehandlingÅrsakType.kodeMap().values());
 
         Map<String, Collection<? extends Kodeverdi>> mapFiltered = new LinkedHashMap<>();
 
@@ -80,7 +82,7 @@ public class HentKodeverkTjeneste {
     private static List<Class<? extends Kodeliste>> KODEVERK_SOM_BRUKES_PÅ_KLIENT = Arrays.asList(
         // Legg inn kodelister etter behov
         BehandlingType.class,
-        BehandlingÅrsakType.class
+        EksternBehandlingÅrsakType.class
     );
 
     public HentKodeverkTjeneste() {


### PR DESCRIPTION
BehandlingÅrsakType er skilt ut i 2 deler, BehandlingÅrsakType enum for å håndtere Fptilbake verdiene og EksternBehandlingÅrsakType kodeverk for å hente fpsak årsakene