### PR TITLE
PFP-9546 

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/grunnlag/KravgrunnlagValidator.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/grunnlag/KravgrunnlagValidator.java
@@ -33,7 +33,7 @@ public class KravgrunnlagValidator {
         KravgrunnlagValidator::validerSkatt,
         KravgrunnlagValidator::validerPerioderHarFeilutbetalingPostering,
         KravgrunnlagValidator::validerPerioderHarYtelPostering,
-        KravgrunnlagValidator::validerPerioderHarNegativFeilutbetaltBeløp,
+        KravgrunnlagValidator::validerPerioderHarFeilPosteringMedNegativFeilutbetaltBeløp,
         KravgrunnlagValidator::validerYtelseMotFeilutbetaling,
         KravgrunnlagValidator::validerYtelPosteringTilbakekrevesMotNyttOgOpprinneligUtbetalt
     );
@@ -131,12 +131,10 @@ public class KravgrunnlagValidator {
         }
     }
 
-    private static void validerPerioderHarNegativFeilutbetaltBeløp(Kravgrunnlag431 kravgrunnlag) {
+    private static void validerPerioderHarFeilPosteringMedNegativFeilutbetaltBeløp(Kravgrunnlag431 kravgrunnlag) {
         for (KravgrunnlagPeriode432 periode : kravgrunnlag.getPerioder()) {
             for (KravgrunnlagBelop433 belop433 : periode.getKravgrunnlagBeloper433()) {
-                if (belop433.getNyBelop().compareTo(BigDecimal.ZERO) < 0 ||
-                    belop433.getOpprUtbetBelop().compareTo(BigDecimal.ZERO) < 0 ||
-                    belop433.getTilbakekrevesBelop().compareTo(BigDecimal.ZERO) < 0) {
+                if(KlasseType.FEIL.equals(belop433.getKlasseType()) && belop433.getNyBelop().compareTo(BigDecimal.ZERO) < 0){
                     throw KravgrunnlagFeil.FACTORY.feilBeløp(periode.getPeriode()).toException();
                 }
             }
@@ -222,7 +220,7 @@ public class KravgrunnlagValidator {
         @IntegrasjonFeil(feilkode = "FPT-615761", feilmelding = "Ugyldig kravgrunnlag. For perioden %s finnes YTEL-postering med tilbakekrevesBeløp %s som er større enn differanse mellom nyttBeløp %s og opprinneligBeløp %s", logLevel = WARN, exceptionClass = UgyldigKravgrunnlagException.class)
         Feil ytelPosteringHvorTilbakekrevesIkkeStemmerMedNyttOgOpprinneligBeløp(Periode periode, BigDecimal tilbakekrevesBeløp, BigDecimal nyttBeløp, BigDecimal opprinneligBeløp);
 
-        @IntegrasjonFeil(feilkode = "FPT-930247", feilmelding = "Ugyldig kravgrunnlag. Perioden %s har postering med negativ beløp", logLevel = WARN, exceptionClass = UgyldigKravgrunnlagException.class)
+        @IntegrasjonFeil(feilkode = "FPT-930247", feilmelding = "Ugyldig kravgrunnlag. Perioden %s har FEIL postering med negativ beløp", logLevel = WARN, exceptionClass = UgyldigKravgrunnlagException.class)
         Feil feilBeløp(Periode periode);
     }
 }

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/grunnlag/KravgrunnlagValidatorTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/grunnlag/KravgrunnlagValidatorTest.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.tilbakekreving.grunnlag;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -20,7 +22,6 @@ public class KravgrunnlagValidatorTest {
     private Kravgrunnlag431 kravgrunnlag = lagKravgrunnlag(Henvisning.fraEksternBehandlingId(1000000L));
     private BigDecimal maxSkattJanuar = BigDecimal.valueOf(100);
 
-
     @Test
     public void skal_godta_kravgrunnlag_som_er_OK() {
         Periode periode = Periode.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 15));
@@ -35,8 +36,8 @@ public class KravgrunnlagValidatorTest {
     public void skal_gi_feilmelding_ved_manglende_referanse_felt() {
         kravgrunnlag = lagKravgrunnlag(null);
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag for kravgrunnlagId 12341. Mangler referanse");
+        var e= assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-879716:Ugyldig kravgrunnlag for kravgrunnlagId 12341. Mangler referanse.",e.getMessage());
     }
 
     @Test
@@ -48,8 +49,8 @@ public class KravgrunnlagValidatorTest {
         leggTilFeilutbetaling(kgPeriode1, 1000);
         leggTilFeilutbetaling(kgPeriode2, 1000);
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag. Overlappende perioder 01.01.2020-10.01.2020 og 06.01.2020-31.01.2020.");
+        var e= assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-936521:Ugyldig kravgrunnlag. Overlappende perioder 01.01.2020-10.01.2020 og 06.01.2020-31.01.2020.",e.getMessage());
     }
 
     @Test
@@ -63,8 +64,8 @@ public class KravgrunnlagValidatorTest {
         leggTilFeilutbetaling(kgPeriode1, 500, skatteprosent);
         leggTilFeilutbetaling(kgPeriode2, 500, skatteprosent);
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag. For måned 2020-01 er maks skatt 299, men maks tilbakekreving ganget med skattesats blir 300");
+        var e= assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-930235:Ugyldig kravgrunnlag. For måned 2020-01 er maks skatt 299, men maks tilbakekreving ganget med skattesats blir 300",e.getMessage());
     }
 
     @Test
@@ -78,8 +79,8 @@ public class KravgrunnlagValidatorTest {
         leggTilYtel(kgPeriode, KlasseKode.FPADSND_OP, 100, skattNæringsdrivende);
         leggTilFeil(kgPeriode, 100 + 100 + 1, BigDecimal.ZERO);
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag. For periode 01.01.2020-15.01.2020 er sum tilkakekreving fra YTEL 200, mens belopNytt i FEIL er 201. Det er forventet at disse er like.");
+        var e = assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class, () -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-361605:Ugyldig kravgrunnlag. For periode 01.01.2020-15.01.2020 er sum tilkakekreving fra YTEL 200, mens belopNytt i FEIL er 201. Det er forventet at disse er like.",e.getMessage());
     }
 
     @Test
@@ -92,8 +93,8 @@ public class KravgrunnlagValidatorTest {
         leggTilYtel(kgPeriode, KlasseKode.FPATORD, 0, skattOrd);
         leggTilYtel(kgPeriode, KlasseKode.FPADSND_OP, 0, skattNæringsdrivende);
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag. Perioden 01.01.2020-15.01.2020 mangler postering med klasseType=FEIL.");
+        var e = assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-727260:Ugyldig kravgrunnlag. Perioden 01.01.2020-15.01.2020 mangler postering med klasseType=FEIL.",e.getMessage());
     }
 
     @Test
@@ -104,8 +105,8 @@ public class KravgrunnlagValidatorTest {
         BigDecimal skattOrd = BigDecimal.valueOf(50);
         leggTilFeil(kgPeriode, 1000,skattOrd);
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag for kravgrunnlagId 12341. Perioden 01.01.2020-15.01.2020 mangler postering med klasseType=YTEL.");
+        var e = assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-727261:Ugyldig kravgrunnlag for kravgrunnlagId 12341. Perioden 01.01.2020-15.01.2020 mangler postering med klasseType=YTEL.",e.getMessage());
     }
 
     @Test
@@ -117,21 +118,8 @@ public class KravgrunnlagValidatorTest {
         leggTilFeil(kgPeriode, -1000,skattOrd);
         leggTilYtel(kgPeriode, KlasseKode.FPATORD, -1000, skattOrd);
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag. Perioden 01.01.2020-15.01.2020 har feil postering med negativ beløp");
-    }
-
-    @Test
-    public void skal_gi_feilmelding_når_perioden_har_YTEL_postering_med_negativt_beløp(){
-        Periode periode1 = Periode.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 15));
-        KravgrunnlagPeriode432 kgPeriode = leggTilKravgrunnlagPeriode(kravgrunnlag, periode1, maxSkattJanuar);
-
-        BigDecimal skattOrd = BigDecimal.valueOf(50);
-        leggTilFeil(kgPeriode, 1000,skattOrd);
-        leggTilYtel(kgPeriode, KlasseKode.FPATORD, -1000, skattOrd);
-
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag. Perioden 01.01.2020-15.01.2020 har feil postering med negativ beløp");
+        var e = assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-930247:Ugyldig kravgrunnlag. Perioden 01.01.2020-15.01.2020 har FEIL postering med negativ beløp",e.getMessage());
     }
 
     @Test
@@ -149,8 +137,8 @@ public class KravgrunnlagValidatorTest {
             .medSkattProsent(BigDecimal.valueOf(0))
             .build());
 
-        assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag),
-            "Ugyldig kravgrunnlag. For perioden 01.01.2020-10.01.2020 finnes YTEL-postering med tilbakekrevesBeløp 1000 som er større enn differanse mellom nyttBeløp 200 og opprinneligBeløp 1000");
+        var e = assertThrows(KravgrunnlagValidator.UgyldigKravgrunnlagException.class,() -> KravgrunnlagValidator.validerGrunnlag(kravgrunnlag));
+        assertEquals("FPT-615761:Ugyldig kravgrunnlag. For perioden 01.01.2020-10.01.2020 finnes YTEL-postering med tilbakekrevesBeløp 1000 som er større enn differanse mellom nyttBeløp 200 og opprinneligBeløp 1000",e.getMessage());
     }
 
     private void leggTilFeilutbetaling(KravgrunnlagPeriode432 kgPeriode, int feilutbetaltBeløp) {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/finn/FinnGrunnlagTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/finn/FinnGrunnlagTaskTest.java
@@ -212,7 +212,8 @@ public class FinnGrunnlagTaskTest extends FellesTestOppsett {
         mottattXmlRepository.oppdaterMedHenvisningOgSaksnummer(ANNEN_HENVISNING, saksnummer, mottattXmlId);
 
         ProsessTaskData prosessTaskData = opprettFinngrunnlagProsessTask();
-        assertThrows("FPT-783524", TekniskException.class, () -> finnGrunnlagTask.doTask(prosessTaskData));
+        var e= assertThrows(TekniskException.class, () -> finnGrunnlagTask.doTask(prosessTaskData));
+        assertThat(e.getMessage()).contains("FPT-783524");
     }
 
     @Test

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/IverksetteVedtakStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/IverksetteVedtakStegImplTest.java
@@ -79,7 +79,8 @@ public class IverksetteVedtakStegImplTest {
 
     @Test
     public void skal_ikke_utføre_iverksette_vedtak_steg_hvis_vedtak_ikke_finnes() {
-        assertThrows("FPT-131240", TekniskException.class, () -> iverksetteVedtakSteg.utførSteg(behandlingskontrollKontekst));
+        var e= assertThrows(TekniskException.class, () -> iverksetteVedtakSteg.utførSteg(behandlingskontrollKontekst));
+        assertThat(e.getMessage()).contains("FPT-131240");
     }
 
     @Test

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteImplTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteImplTest.java
@@ -163,8 +163,10 @@ public class BehandlingTjenesteImplTest extends FellesTestOppsett {
         SamletEksternBehandlingInfo samletEksternBehandlingInfo = lagSamletEksternBehandlingInfo(VergeType.BARN);
         when(mockFagsystemKlient.hentBehandlingsinfo(any(UUID.class), any(Tillegsinformasjon.class))).thenReturn(samletEksternBehandlingInfo);
         when(mockTpsTjeneste.hentAktørForFnr(any(PersonIdent.class))).thenReturn(Optional.empty());
-        Assert.assertThrows("FPT-7428494", TekniskException.class, () -> behandlingTjeneste.opprettBehandlingAutomatisk(saksnummer, UUID.randomUUID(),
+        UUID uuid = UUID.randomUUID();
+        var e= Assert.assertThrows(TekniskException.class, () -> behandlingTjeneste.opprettBehandlingAutomatisk(saksnummer, uuid,
             henvisning, aktørId, FagsakYtelseType.FORELDREPENGER, BehandlingType.TILBAKEKREVING));
+        assertThat(e.getMessage()).contains("FPT-7428494");
     }
 
     @Test

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/verge/AvklartVergeTjenesteTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/verge/AvklartVergeTjenesteTest.java
@@ -63,8 +63,9 @@ public class AvklartVergeTjenesteTest extends FellesTestOppsett {
     public void skal_ikke_lagre_verge_informasjon_når_verge_er_advokat_men_orgnummer_ikke_finnes()  {
         VergeDto vergeDto = lagVergeDto(VergeType.ADVOKAT);
         when(virksomhetTjenesteMock.validerOrganisasjon(anyString())).thenReturn(false);
-        Assert.assertThrows("OrgansisasjonNummer er ikke gyldig", IllegalStateException.class,
+        var e= Assert.assertThrows(IllegalStateException.class,
             () -> avklartVergeTjeneste.lagreVergeInformasjon(internBehandlingId, vergeDto));
+        assertThat(e.getMessage()).contains("OrgansisasjonNummer er ikke gyldig");
     }
 
     private void fellesVergeAssert(VergeDto vergeDto, VergeEntitet vergeEntitet) {
@@ -84,7 +85,7 @@ public class AvklartVergeTjenesteTest extends FellesTestOppsett {
         assertThat(historikkinnslagDeler).isNotEmpty();
         assertThat(historikkinnslagDeler.size()).isEqualTo(1);
         assertThat(historikkinnslagDeler.get(0).getSkjermlenke()).isNotEmpty();
-        assertThat(historikkinnslagDeler.get(0).getSkjermlenke().get()).isEqualTo(SkjermlenkeType.FAKTA_OM_VERGE.getKode());
+        assertThat(historikkinnslagDeler.get(0).getSkjermlenke().get()).contains(SkjermlenkeType.FAKTA_OM_VERGE.getKode());
         assertThat(historikkinnslagDeler.get(0).getHendelse()).isNotEmpty();
     }
 

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/henleggelse/HenleggelsesbrevTjenesteTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/henleggelse/HenleggelsesbrevTjenesteTest.java
@@ -125,15 +125,17 @@ public class HenleggelsesbrevTjenesteTest extends DokumentBestillerTestOppsett {
 
     @Test
     public void skal_ikke_sende_henleggelsesbrev_hvis_varselbrev_ikke_sendt() {
-        assertThrows("FPT-110801", FunksjonellException.class, () ->
+        var e = assertThrows(FunksjonellException.class, () ->
             henleggelsesbrevTjeneste.sendHenleggelsebrev(behandlingId, null, BrevMottaker.BRUKER));
+        assertThat(e.getMessage()).contains("FPT-110801");
     }
 
     @Test
     public void skal_ikke_sende_henleggelsesbrev_for_tilbakekreving_revurdering_uten_fritekst() {
         Long revurderingBehandlingId = opprettOgForberedTilbakekrevingRevurdering();
-        assertThrows("FPT-110802", FunksjonellException.class, () ->
+        var e= assertThrows(FunksjonellException.class, () ->
             henleggelsesbrevTjeneste.sendHenleggelsebrev(revurderingBehandlingId, null, BrevMottaker.BRUKER));
+        assertThat(e.getMessage()).contains("FPT-110802");
     }
 
     private void lagreVarselBrevSporing() {

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
@@ -184,7 +184,8 @@ public class BehandlingRestTjenesteTest {
     public void skal_ikke_returnere_vedtak_info_hvis_tilbakekreving_ikke_er_avsluttet() {
         Behandling behandling = ScenarioSimple.simple().lagMocked();
         when(behandlingTjenesteMock.hentBehandling(any(UUID.class))).thenReturn(behandling);
-        assertThrows("FPT-763492", TekniskException.class, () -> behandlingRestTjeneste.hentTilbakekrevingsVedtakInfo(uuidDto));
+        var e = assertThrows(TekniskException.class, () -> behandlingRestTjeneste.hentTilbakekrevingsVedtakInfo(uuidDto));
+        assertThat(e.getMessage()).contains("FPT-763492");
     }
 
     @Test
@@ -192,7 +193,8 @@ public class BehandlingRestTjenesteTest {
         Behandling behandling = ScenarioSimple.simple().lagMocked();
         behandling.avsluttBehandling();
         when(behandlingTjenesteMock.hentBehandling(any(UUID.class))).thenReturn(behandling);
-        assertThrows("FPT-763492", TekniskException.class, () -> behandlingRestTjeneste.hentTilbakekrevingsVedtakInfo(uuidDto));
+        var e = assertThrows(TekniskException.class, () -> behandlingRestTjeneste.hentTilbakekrevingsVedtakInfo(uuidDto));
+        assertThat(e.getMessage()).contains("FPT-763492");
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/HentKorrigertKravgrunnlagTaskTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/HentKorrigertKravgrunnlagTaskTest.java
@@ -104,7 +104,8 @@ public class HentKorrigertKravgrunnlagTaskTest {
     public void skal_ikke_hente_og_lagre_korrigert_kravgrunnlag_når_hentet_grunnlaget_er_ugyldig() {
         when(økonomiConsumerMock.hentKravgrunnlag(anyLong(), any(HentKravgrunnlagDetaljDto.class))).thenReturn(lagKravgrunnlag(false));
         ProsessTaskData prosessTaskData = lagProsessTaskData();
-        assertThrows("FPT-879715", IntegrasjonException.class, () -> hentKorrigertGrunnlagTask.doTask(prosessTaskData));
+        var e= assertThrows(IntegrasjonException.class, () -> hentKorrigertGrunnlagTask.doTask(prosessTaskData));
+        assertThat(e.getMessage()).contains("FPT-734548");
     }
 
     @Test
@@ -133,7 +134,8 @@ public class HentKorrigertKravgrunnlagTaskTest {
         eksternBehandlingRepository.lagre(eksternBehandling);
         when(fagsystemKlient.hentBehandlingForSaksnummer(anyString())).thenReturn(Lists.newArrayList(lagEksternBehandlingsInfo(2l)));
         ProsessTaskData prosessTaskData = lagProsessTaskData();
-        assertThrows("FPT-587197", TekniskException.class, () -> hentKorrigertGrunnlagTask.doTask(prosessTaskData));
+        var e= assertThrows(TekniskException.class, () -> hentKorrigertGrunnlagTask.doTask(prosessTaskData));
+        assertThat(e.getMessage()).contains("FPT-587197");
     }
 
 

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/verge/VergeRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/verge/VergeRestTjenesteTest.java
@@ -20,6 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import no.nav.foreldrepenger.tilbakekreving.behandling.BehandlingTjeneste;
+import no.nav.foreldrepenger.tilbakekreving.behandling.dto.BehandlingReferanse;
 import no.nav.foreldrepenger.tilbakekreving.behandling.impl.verge.VergeTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
@@ -32,7 +33,6 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.verge.Ve
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.testutilities.kodeverk.ScenarioSimple;
 import no.nav.foreldrepenger.tilbakekreving.dbstoette.UnittestRepositoryRule;
 import no.nav.foreldrepenger.tilbakekreving.domene.person.TpsTjeneste;
-import no.nav.foreldrepenger.tilbakekreving.behandling.dto.BehandlingReferanse;
 import no.nav.vedtak.exception.TekniskException;
 
 public class VergeRestTjenesteTest {
@@ -50,7 +50,9 @@ public class VergeRestTjenesteTest {
         Behandling behandling = ScenarioSimple.simple().lagMocked();
         behandling.avsluttBehandling();
         when(behandlingTjenesteMock.hentBehandling(anyLong())).thenReturn(behandling);
-        assertThrows("FPT-763493", TekniskException.class, () -> vergeRestTjeneste.opprettVerge(new BehandlingReferanse(behandling.getId())));
+        BehandlingReferanse behandlingReferanse = new BehandlingReferanse(behandling.getId());
+        var e= assertThrows(TekniskException.class, () -> vergeRestTjeneste.opprettVerge(behandlingReferanse));
+        assertThat(e.getMessage()).contains("FPT-763493");
     }
 
     @Test
@@ -59,7 +61,9 @@ public class VergeRestTjenesteTest {
         scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG, BehandlingStegType.TBKGSTEG);
         Behandling behandling = scenario.lagre(repositoryProvider);
         when(behandlingTjenesteMock.hentBehandling(anyLong())).thenReturn(behandling);
-        assertThrows("FPT-763493", TekniskException.class, () -> vergeRestTjeneste.opprettVerge(new BehandlingReferanse(behandling.getId())));
+        BehandlingReferanse behandlingReferanse = new BehandlingReferanse(behandling.getId());
+        var e= assertThrows(TekniskException.class, () -> vergeRestTjeneste.opprettVerge(behandlingReferanse));
+        assertThat(e.getMessage()).contains("FPT-763493");
     }
 
     @Test
@@ -68,7 +72,9 @@ public class VergeRestTjenesteTest {
         scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_VERGE, BehandlingStegType.FAKTA_FEILUTBETALING);
         Behandling behandling = scenario.lagre(repositoryProvider);
         when(behandlingTjenesteMock.hentBehandling(anyLong())).thenReturn(behandling);
-        assertThrows("FPT-185321", TekniskException.class, () -> vergeRestTjeneste.opprettVerge(new BehandlingReferanse(behandling.getId())));
+        BehandlingReferanse behandlingReferanse = new BehandlingReferanse(behandling.getId());
+        var e= assertThrows(TekniskException.class, () -> vergeRestTjeneste.opprettVerge(behandlingReferanse));
+        assertThat(e.getMessage()).contains("FPT-185321");
     }
 
     @Test
@@ -86,7 +92,9 @@ public class VergeRestTjenesteTest {
         Behandling behandling = ScenarioSimple.simple().lagMocked();
         behandling.avsluttBehandling();
         when(behandlingTjenesteMock.hentBehandling(anyLong())).thenReturn(behandling);
-        assertThrows("FPT-763494", TekniskException.class, () -> vergeRestTjeneste.fjernVerge(new BehandlingReferanse(behandling.getId())));
+        BehandlingReferanse behandlingReferanse = new BehandlingReferanse(behandling.getId());
+        var e= assertThrows(TekniskException.class, () -> vergeRestTjeneste.fjernVerge(behandlingReferanse));
+        assertThat(e.getMessage()).contains("FPT-763494");
     }
 
     @Test
@@ -95,7 +103,9 @@ public class VergeRestTjenesteTest {
         scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG, BehandlingStegType.TBKGSTEG);
         Behandling behandling = scenario.lagre(repositoryProvider);
         when(behandlingTjenesteMock.hentBehandling(anyLong())).thenReturn(behandling);
-        assertThrows("FPT-763494", TekniskException.class, () -> vergeRestTjeneste.fjernVerge(new BehandlingReferanse(behandling.getId())));
+        BehandlingReferanse behandlingReferanse = new BehandlingReferanse(behandling.getId());
+        var e= assertThrows(TekniskException.class, () -> vergeRestTjeneste.fjernVerge(behandlingReferanse));
+        assertThat(e.getMessage()).contains("FPT-763494");
     }
 
     @Test


### PR DESCRIPTION
endret kravgrunnlag validering for å hindre kravgrunnlag med negativ beløp for kun FEIL postering. fikset assertThrows forbruk.