### PR TITLE
NOJIRA hent fagsak uten å slå opp i tps/pdl

### DIFF
--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/Tillegsinformasjon.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/Tillegsinformasjon.java
@@ -5,7 +5,7 @@ public enum Tillegsinformasjon {
     VARSELTEKST("tilbakekrevingsvarsel-fritekst"),
     SØKNAD("soknad"),
     TILBAKEKREVINGSVALG("tilbakekreving-valg", "tilbakekrevingvalg"),
-    FAGSAK("fagsak"),
+    FAGSAK("fagsak-backend"),
     VERGE("verge");
 
     private String fpsakRelasjonNavn;


### PR DESCRIPTION
Bruker et endepunkt som ikke slår opp persondata i TPS/PDL for hvert kall. 
Den har med aktørId for fagsaken og det som finnes i FagsakDto