### PR TITLE
Feiler tidligere ved null eller blank fritekst periode

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/brev/VedtaksbrevFritekstPeriode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/brev/VedtaksbrevFritekstPeriode.java
@@ -112,6 +112,10 @@ public class VedtaksbrevFritekstPeriode extends BaseEntitet {
         public VedtaksbrevFritekstPeriode build() {
             Objects.requireNonNull(vedtaksbrevFritekstPeriode.behandlingId);
             Objects.requireNonNull(vedtaksbrevFritekstPeriode.periode);
+            Objects.requireNonNull(vedtaksbrevFritekstPeriode.fritekstType);
+            if (vedtaksbrevFritekstPeriode.fritekst == null || vedtaksbrevFritekstPeriode.fritekst.isBlank()) {
+                throw new IllegalArgumentException("Mangler fritekst");
+            }
             return vedtaksbrevFritekstPeriode;
         }
     }


### PR DESCRIPTION
For å unngå feilmeldingen som CallId_1606833069427_720807054. Feile før den får error fra db