### PR TITLE
TFP-4316 Fjerner tekst for brev vedrørende ingen tilbakekreving trigg…

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/feilutbetalingårsak/kodeverk/HendelseUnderType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/feilutbetalingårsak/kodeverk/HendelseUnderType.java
@@ -98,7 +98,8 @@ public enum HendelseUnderType implements Kodeverdi {
     LEGACY_ØKONOMI_UTBETALT_FOR_MYE("ØKONOMI_UTBETALT_FOR_MYE", "Feil i økonomi - utbetalt for mye", 1),
     //FELLES
     REFUSJON_ARBEIDSGIVER("REFUSJON_ARBGIVER", "Refusjon til arbeidsgiver", 1),
-    ANNET_FRITEKST("ANNET_FRITEKST", "Annet - fritekst", 3),
+    ANNET_FRITEKST("ANNET_FRITEKST", "Annet - fritekst", 2),
+    FEIL_FERIEPENGER_4G("FEIL_FERIEPENGER_4G", "Feil i feriepenger - under 4G", 3),
     IKKE_SATT("-", null, 0),
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/feilutbetalingårsak/kodeverk/HendelseUndertypePrHendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/feilutbetalingårsak/kodeverk/HendelseUndertypePrHendelseType.java
@@ -46,7 +46,8 @@ public class HendelseUndertypePrHendelseType {
             HendelseUnderType.ES_BRUKER_RETT_FORELDREPENGER));
         h.put(HendelseType.FP_ANNET_HENDELSE_TYPE, Set.of(
             HendelseUnderType.ANNET_FRITEKST,
-            HendelseUnderType.REFUSJON_ARBEIDSGIVER));
+            HendelseUnderType.REFUSJON_ARBEIDSGIVER,
+            HendelseUnderType.FEIL_FERIEPENGER_4G));
         h.put(HendelseType.FP_KUN_RETT_TYPE, Set.of(
             HendelseUnderType.FEIL_I_ANTALL_DAGER));
         h.put(HendelseType.MEDLEMSKAP_TYPE, Set.of(
@@ -78,7 +79,8 @@ public class HendelseUndertypePrHendelseType {
             HendelseUnderType.OPPHOR_MOTTAKER_DOD));
         h.put(HendelseType.SVP_ANNET_TYPE, Set.of(
             HendelseUnderType.ANNET_FRITEKST,
-            HendelseUnderType.REFUSJON_ARBEIDSGIVER));
+            HendelseUnderType.REFUSJON_ARBEIDSGIVER,
+            HendelseUnderType.FEIL_FERIEPENGER_4G));
         h.put(HendelseType.SVP_ARBEIDSGIVERS_FORHOLD_TYPE, Set.of(
             HendelseUnderType.SVP_TILRETTELEGGING_DELVIS_MULIG,
             HendelseUnderType.SVP_TILRETTELEGGING_FULLT_MULIG));

--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/feilutbetalingårsak/tjeneste/FaktaFeilutbetalingÅrsakTjenesteTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/feilutbetalingårsak/tjeneste/FaktaFeilutbetalingÅrsakTjenesteTest.java
@@ -96,7 +96,8 @@ public class FaktaFeilutbetalingÅrsakTjenesteTest {
 
         assertThat(mapAvResultat.get(HendelseType.FP_ANNET_HENDELSE_TYPE)).containsExactly(
             HendelseUnderType.REFUSJON_ARBEIDSGIVER,
-            HendelseUnderType.ANNET_FRITEKST
+            HendelseUnderType.ANNET_FRITEKST,
+            HendelseUnderType.FEIL_FERIEPENGER_4G
         );
 
         assertThat(mapAvResultat.get(HendelseType.FP_KUN_RETT_TYPE)).containsOnly(
@@ -166,9 +167,10 @@ public class FaktaFeilutbetalingÅrsakTjenesteTest {
             HendelseUnderType.SVP_ENDRING_PERIODE
         );
 
-        assertThat(mapAvResultat.get(HendelseType.SVP_ANNET_TYPE)).containsOnly(
+        assertThat(mapAvResultat.get(HendelseType.SVP_ANNET_TYPE)).containsExactly(
             HendelseUnderType.REFUSJON_ARBEIDSGIVER,
-            HendelseUnderType.ANNET_FRITEKST
+            HendelseUnderType.ANNET_FRITEKST,
+            HendelseUnderType.FEIL_FERIEPENGER_4G
         );
     }
 

--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtaksbrevTjeneste.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtaksbrevTjeneste.java
@@ -15,6 +15,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.feilutbetalingårsak.kodeverk.HendelseUnderType;
 import org.apache.commons.lang3.StringUtils;
 
 import com.github.jknack.handlebars.internal.text.WordUtils;
@@ -279,6 +280,7 @@ public class VedtaksbrevTjeneste {
             .medVarsel(HbVarsel.forDatoOgBeløp(varsletDato, varsletBeløp))
             .medErFeilutbetaltBeløpKorrigertNed(erFeilutbetaltBeløpKorrigertNed)
             .medTotaltFeilutbetaltBeløp(hbVedtaksResultatBeløp.totaltFeilutbetaltBeløp)
+            .medSkalFjerneTekstFeriepenger(skalFjerneTekstFeriepenger(perioder))
             .medFritekstOppsummering(oppsummeringFritekst)
             .medVedtaksbrevType(vedtaksbrevType)
             .medLovhjemmelVedtak(hjemmelstekst)
@@ -297,6 +299,9 @@ public class VedtaksbrevTjeneste {
         return new HbVedtaksbrevData(vedtakDataBuilder.build(), perioder);
     }
 
+    private boolean skalFjerneTekstFeriepenger(List<HbVedtaksbrevPeriode> perioder) {
+        return perioder.stream().anyMatch(p-> HendelseUnderType.FEIL_FERIEPENGER_4G.equals(p.getFakta().getHendelseundertype()));
+    }
     private VedtakHjemmel.EffektForBruker utledEffektForBruker(Behandling behandling, HbVedtaksResultatBeløp hbVedtaksResultatBeløp) {
         boolean erRevurdering = BehandlingType.REVURDERING_TILBAKEKREVING.equals(behandling.getType());
         return erRevurdering

--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/handlebars/dto/HbVedtaksbrevFelles.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/handlebars/dto/HbVedtaksbrevFelles.java
@@ -42,6 +42,9 @@ public class HbVedtaksbrevFelles implements HandlebarsData {
     private boolean erFeilutbetaltBeløpKorrigertNed;
     @JsonProperty("totalt-feilutbetalt-beløp")
     private BigDecimal totaltFeilutbetaltBeløp;
+    @JsonProperty("skalFjerneTekstFeriepenger")
+    private boolean skalFjerneTekstFeriepenger;
+
 
     private HbVedtaksbrevDatoer datoer;
 
@@ -220,6 +223,11 @@ public class HbVedtaksbrevFelles implements HandlebarsData {
 
         public Builder medTotaltFeilutbetaltBeløp(BigDecimal totaltFeilutbetaltBeløp) {
             kladd.totaltFeilutbetaltBeløp = totaltFeilutbetaltBeløp;
+            return this;
+        }
+
+        public Builder medSkalFjerneTekstFeriepenger(boolean medSkalFjerneTekstFeriepenger) {
+            kladd.skalFjerneTekstFeriepenger = medSkalFjerneTekstFeriepenger;
             return this;
         }
     }

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/periode-fakta/periode_fakta_fp.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/periode-fakta/periode_fakta_fp.hbs
@@ -155,6 +155,8 @@ Du har jobbet samtidig som at du har fått utbetalt foreldrepenger. Fordi du har
         {{/case}}
         {{#case "ANNET_FRITEKST"}}
         {{/case}}
+        {{#case "FEIL_FERIEPENGER_4G"}}
+        {{/case}}
     {{/switch}}
 {{/case}}
 {{/switch}}

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/periode-fakta/periode_fakta_svp.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/periode-fakta/periode_fakta_svp.hbs
@@ -85,6 +85,8 @@ Fordi svangerskapspengene er blitt utbetalt fra denne datoen, har du fått {{kro
         {{/case}}
         {{#case "ANNET_FRITEKST"}}
         {{/case}}
+        {{#case "FEIL_FERIEPENGER_4G"}}
+        {{/case}}
     {{/switch}}
 {{/case}}
 {{/switch}}

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/vedtak_overskrift.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/vedtak_overskrift.hbs
@@ -9,6 +9,6 @@ Du må betale tilbake {{> ytelsen}}
 Du må betale tilbake {{> ytelsen}}
     {{/case}}
     {{#case "INGEN_TILBAKEBETALING"}}
-Du må ikke betale tilbake {{> ytelsen}}
+Du må ikke betale tilbake {{#if skalFjerneTekstFeriepenger}}feriepengene{{else}}{{> ytelsen}}{{/if}}
     {{/case}}
 {{/switch}}

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/vedtak_start_u_skatt.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nb/vedtak/vedtak_start_u_skatt.hbs
@@ -1,3 +1,6 @@
+{{~#* inline "ytelsen" ~}}
+    {{lookup-map sak.ytelsetype FP="foreldrepengene" SVP="svangerskapspengene" ES="engangsstønaden" FRISINN="kompensasjonsytelse for selvstendig næringsdrivende og frilansere"}}
+{{~/inline~}}
 {{~#* inline "evt-renter-utsagn" ~}}{{#if totalresultat.totalt-rentebeløp}} Dette beløpet er med renter.{{/if}}{{~/inline~}}
 {{#if behandling.er-revurdering}}
 Vi har vurdert saken din om tilbakebetaling på nytt. Derfor gjelder ikke det tidligere vedtaket av {{behandling.original-behandling-dato-fagsakvedtak}} om tilbakebetaling av {{>ytelse-produkt}}.
@@ -16,6 +19,9 @@ Vi varslet deg {{varsel.varslet-dato}} om at du har fått {{kroner varsel.varsle
     {{/case}}
     {{/switch}}
 {{else}}
+{{#if skalFjerneTekstFeriepenger}}
+Du mottok {{> ytelsen}} i 2019 og tjente opp rett til feriepenger, som ble utbetalt i mai 2020. Feriepengene er endret i våre systemer på grunn av en feil i feriepengeutbetalingen i mai 2020. Du må ikke betale tilbake det du har fått for mye.
+{{else}}
 {{~#* inline "brev-ytelse-endret" ~}}I brev {{sak.dato-fagsakvedtak}} fikk du melding om at {{>ytelse-produkt}} {{>din-dine}} er endret. Endringen gjorde at du har fått utbetalt for mye.{{~/inline~}}
     {{#switch totalresultat.hovedresultat}}
     {{#case "FULL_TILBAKEBETALING"}}
@@ -28,6 +34,7 @@ Vi varslet deg {{varsel.varslet-dato}} om at du har fått {{kroner varsel.varsle
 {{>brev-ytelse-endret}} Du må ikke betale tilbake det du har fått for mye.
     {{/case}}
     {{/switch}}
+{{/if}}
 {{/if}}
 {{#if fritekst-oppsummering}}
 

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/periode-fakta/periode_fakta_fp.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/periode-fakta/periode_fakta_fp.hbs
@@ -155,6 +155,8 @@ Du har jobba samtidig som at du har fått utbetalt foreldrepengar. Fordi du har 
         {{/case}}
         {{#case "ANNET_FRITEKST"}}
         {{/case}}
+        {{#case "FEIL_FERIEPENGER_4G"}}
+        {{/case}}
     {{/switch}}
 {{/case}}
 {{/switch}}

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/periode-fakta/periode_fakta_svp.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/periode-fakta/periode_fakta_svp.hbs
@@ -85,6 +85,8 @@ Fordi svangerskapspengane er blitt utbetalt frå denne datoen, har du fått {{kr
         {{/case}}
         {{#case "ANNET_FRITEKST"}}
         {{/case}}
+        {{#case "FEIL_FERIEPENGER_4G"}}
+        {{/case}}
     {{/switch}}
 {{/case}}
 {{/switch}}

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/vedtak_overskrift.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/vedtak_overskrift.hbs
@@ -9,6 +9,6 @@ Du må betale tilbake {{> ytelsen}}
 Du må betale tilbake {{> ytelsen}}
     {{/case}}
     {{#case "INGEN_TILBAKEBETALING"}}
-Du må ikkje betale tilbake {{> ytelsen}}
+Du må ikkje betale tilbake {{#if skalFjerneTekstFeriepenger}}feriepengene{{else}}{{> ytelsen}}{{/if}}
     {{/case}}
 {{/switch}}

--- a/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/vedtak_start_u_skatt.hbs
+++ b/integrasjontjenester/dokumentbestiller/src/main/resources/templates/nn/vedtak/vedtak_start_u_skatt.hbs
@@ -1,3 +1,6 @@
+{{~#* inline "ytelsen" ~}}
+    {{lookup-map sak.ytelsetype FP="foreldrepengane" SVP="svangerskapspengane" ES="eingongsstønaden" FRISINN="kompensasjonsytelse for selvstendig næringsdrivende og frilansere"}}
+{{~/inline~}}
 {{~#* inline "evt-renter-utsagn" ~}}{{#if totalresultat.totalt-rentebeløp}} Dette beløpet er med renter.{{/if}}{{~/inline~}}
 {{#if behandling.er-revurdering}}
 Vi har vurdert saka di om tilbakebetaling på nytt. Derfor gjeld ikkje det tidlegare vedtaket av {{behandling.original-behandling-dato-fagsakvedtak}} om tilbakebetaling av {{>ytelse-produkt}}.
@@ -17,6 +20,9 @@ Vi varsla deg {{varsel.varslet-dato}} om at du har fått {{kroner varsel.varslet
     {{/switch}}
 
 {{else}}
+{{#if skalFjerneTekstFeriepenger}}
+Du mottok {{> ytelsen}} i 2019 og tente opp rett til feriepengar, som vart utbetalte i mai 2020. Feriepengane er endra i systema våre på grunn av ein feil i feriepengeutbetalinga i mai 2020. Du må ikkje betala tilbake det du har fått for mykje.
+{{else}}
 {{~#* inline "brev-ytelse-endret" ~}}I brev {{sak.dato-fagsakvedtak}} fikk du melding om at {{>ytelse-produkt}} {{>din-dine}} er endra. Endringa gjorde at du har fått utbetalt for mykje.{{~/inline~}}
     {{#switch totalresultat.hovedresultat}}
     {{#case "FULL_TILBAKEBETALING"}}
@@ -30,6 +36,7 @@ Vi varsla deg {{varsel.varslet-dato}} om at du har fått {{kroner varsel.varslet
     {{/case}}
     {{/switch}}
 
+{{/if}}
 {{/if}}
 {{#if fritekst-oppsummering}}
 {{{fritekst-oppsummering}}}

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest.java
@@ -120,7 +120,7 @@ public class TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest {
 
         String feilmelding = "";
         for (Map.Entry<Set<HendelseMedUndertype>, String> entry : hendelseTypeTilTeskst.entrySet()) {
-            if (entry.getKey().size() > 1) {
+            if (entry.getKey().size() > 2) {
                 feilmelding += entry.getValue() + " mapper alle til " + entry.getKey() + "\n";
             }
         }

--- a/integrasjontjenester/dokumentbestiller/src/test/resources/vedtaksbrev/FP_ingen_tilbakekreving_feil_feriepenger.txt
+++ b/integrasjontjenester/dokumentbestiller/src/test/resources/vedtaksbrev/FP_ingen_tilbakekreving_feil_feriepenger.txt
@@ -1,0 +1,18 @@
+Du mottok foreldrepengene i 2019 og tjente opp rett til feriepenger, som ble utbetalt i mai 2020. Feriepengene er endret i våre systemer på grunn av en feil i feriepengeutbetalingen i mai 2020. Du må ikke betale tilbake det du har fått for mye.
+_Gjelder perioden fra og med 1. januar 2019 til og med 31. januar 2019
+_Hvordan har vi kommet fram til at du ikke må betale tilbake?
+Vi har ikke gitt deg den informasjonen du trengte for å forstå at beløpet du fikk utbetalt var feil. Du må ikke betale tilbake fordi vi har opplysninger om at du ikke har noe igjen av pengene.
+
+Vedtaket er gjort etter Folketrygdloven § 22-15.
+_Du har rett til å klage
+Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på nav.no/klage.
+_Du har rett til innsyn
+På nav.no/dittnav kan du se dokumentene i saken din.
+_Har du spørsmål?
+Du finner nyttig informasjon på nav.no/familie.
+
+Med vennlig hilsen
+NAV Familie- og pensjonsytelser
+
+
+Vedlegg: Resultatet av tilbakebetalingssaken

--- a/integrasjontjenester/dokumentbestiller/src/test/resources/vedtaksbrev/SVP_ingen_tilbakekreving_feil_feriepenger.txt
+++ b/integrasjontjenester/dokumentbestiller/src/test/resources/vedtaksbrev/SVP_ingen_tilbakekreving_feil_feriepenger.txt
@@ -1,0 +1,18 @@
+Du mottok svangerskapspengene i 2019 og tjente opp rett til feriepenger, som ble utbetalt i mai 2020. Feriepengene er endret i våre systemer på grunn av en feil i feriepengeutbetalingen i mai 2020. Du må ikke betale tilbake det du har fått for mye.
+_Gjelder perioden fra og med 1. mai 2020 til og med 31. mai 2020
+_Hvordan har vi kommet fram til at du ikke må betale tilbake?
+Vi har ikke gitt deg den informasjonen du trengte for å forstå at beløpet du fikk utbetalt var feil. Du må ikke betale tilbake fordi vi har opplysninger om at du ikke har noe igjen av pengene.
+
+Vedtaket er gjort etter Folketrygdloven § 22-15.
+_Du har rett til å klage
+Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på nav.no/klage.
+_Du har rett til innsyn
+På nav.no/dittnav kan du se dokumentene i saken din.
+_Har du spørsmål?
+Du finner nyttig informasjon på nav.no/familie.
+
+Med vennlig hilsen
+NAV Familie- og pensjonsytelser
+
+
+Vedlegg: Resultatet av tilbakebetalingssaken


### PR DESCRIPTION
…et av revurdering pga feil på feriepenger i fpsak. Koden er derfor midlertidig for å hindre forvirrende tekst til bruker.