### PR TITLE
Bumper felles, prosesstaks, fp-kontrakter + rydding i pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <!-- Felles avhengigheter i prosjektet Disse skal ALLTID være en
             RELEASE-avhengighet UNNTAK: feature-brancher og lokalt -->
-        <felles.version>0.0.0-SNAPSHOT</felles.version>
+        <felles.version>3.2.121</felles.version>
         <prosesstask.version>2.6.3</prosesstask.version>
         <fp-tidsserie.version>2.5.7</fp-tidsserie.version>
         <fpkontrakter.version>6.0.1</fpkontrakter.version>


### PR DESCRIPTION
Bumpt felles 3.2.121
Bumpt prosesstask 2.6.3
Bump fp-kontrakter 6.0.1
Samme versjon av felles i repo brukes i prosesstask + rydding i pom