### PR TITLE
Fikser redirect lenker.

### DIFF
--- a/.deploy/fp/dev-fss-teamforeldrepenger.json
+++ b/.deploy/fp/dev-fss-teamforeldrepenger.json
@@ -10,10 +10,11 @@
   "ingresses": [
     "https://fptilbake-q1.nais.preprod.local/",
     "https://app-q1.adeo.no/fptilbake",
-    "https://fptilbake-q1.dev.adeo.no/"
+    "https://fptilbake-q1.dev.adeo.no/",
+    "https://fptilbake.dev.adeo.no/"
   ],
   "env": {
-    "LOADBALANCER_FQDN": "app-q1.adeo.no",
+    "LOADBALANCER_FQDN": "fptilbake.dev.adeo.no",
     "ABAC_PDP_ENDPOINT_URL": "http://abac-foreldrepenger.teamabac/application/authorize",
     "SECURITYTOKENSERVICE_URL": "https://sts-q1.preprod.local/SecurityTokenServiceProvider/",
     "OIDC_STS_ISSUER_URL": "https://security-token-service.nais.preprod.local",

--- a/.deploy/fp/prod-fss-teamforeldrepenger.json
+++ b/.deploy/fp/prod-fss-teamforeldrepenger.json
@@ -12,7 +12,7 @@
     "https://app.adeo.no/fptilbake"
   ],
   "env": {
-    "LOADBALANCER_FQDN": "app.adeo.no",
+    "LOADBALANCER_FQDN": "fptilbake.nais.adeo.no",
     "ABAC_PDP_ENDPOINT_URL": "http://abac-foreldrepenger.teamabac/application/authorize",
     "SECURITYTOKENSERVICE_URL": "https://sts.adeo.no/SecurityTokenServiceProvider/",
     "OIDC_STS_ISSUER_URL": "https://security-token-service.nais.adeo.no",


### PR DESCRIPTION
Swagger har startet å feile med `Refused to load the script 'https://fptilbake.nais.adeo.no/fptilbake/swagger-ui/3.51.2/swagger-ui-standalone-preset.js' because it violates the following Content Security Policy directive: "script-src https://app.adeo.no". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.`