### PR TITLE
Bump kafka-clients from 2.8.0 to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>2.8.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.javaslang</groupId>


### PR DESCRIPTION
Bumps kafka-clients from 2.8.0 to 3.0.0.

---
updated-dependencies:
- dependency-name: org.apache.kafka:kafka-clients
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>