### PR TITLE
Fjerne masete logging

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/VurderProsessTaskStatusForPollingApi.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/VurderProsessTaskStatusForPollingApi.java
@@ -73,7 +73,7 @@ public class VurderProsessTaskStatusForPollingApi {
     }
 
     private Optional<AsyncPollingStatus> håndterFeil(String gruppe, ProsessTaskData task, String callId) {
-        log.warn(String.format("FPT-193308:[%1$s]. Forespørsel på behandling [id=%2$s] som ikke kan fortsette, Problemer med task gruppe [%3$s]. Siste prosesstask[id=%4$s] status=%5$s", callId, entityId, gruppe, task.getId(), task.getStatus()));
+        log.info(String.format("FPT-193308:[%1$s]. Forespørsel på behandling [id=%2$s] som ikke kan fortsette, Problemer med task gruppe [%3$s]. Siste prosesstask[id=%4$s] status=%5$s", callId, entityId, gruppe, task.getId(), task.getStatus()));
 
         AsyncPollingStatus status = new AsyncPollingStatus(AsyncPollingStatus.Status.HALTED, null, task.getSisteFeil());
         return Optional.of(status); // fortsett å polle på gruppe, er ikke ferdig.
@@ -81,7 +81,7 @@ public class VurderProsessTaskStatusForPollingApi {
 
     private Optional<AsyncPollingStatus> ventPåSvar(String gruppe, ProsessTaskData task, String callId) {
         var feil = ProsessTaskFeilmelder.venterPåSvar(callId, entityId, gruppe, task.getId(), task.getStatus());
-        logWarn(feil);
+        logInfo(feil);
 
         AsyncPollingStatus status = new AsyncPollingStatus(
                 AsyncPollingStatus.Status.DELAYED,
@@ -91,8 +91,8 @@ public class VurderProsessTaskStatusForPollingApi {
         return Optional.of(status); // er ikke ferdig, men ok å videresende til visning av behandling med feilmelding der.
     }
 
-    private void logWarn(TekniskException feil) {
-        log.warn("{}: {}", feil.getKode(), feil.getMessage());
+    private void logInfo(TekniskException feil) {
+        log.info("{}: {}", feil.getKode(), feil.getMessage());
     }
 
     private Optional<AsyncPollingStatus> ventPåKlar(String gruppe, LocalDateTime maksTidFørNesteKjøring, ProsessTaskData task, String callId) {
@@ -108,7 +108,7 @@ public class VurderProsessTaskStatusForPollingApi {
         } else {
             var feil = ProsessTaskFeilmelder.utsattKjøringAvProsessTask(
                     callId, entityId, gruppe, task.getId(), task.getStatus(), task.getNesteKjøringEtter());
-            logWarn(feil);
+            logInfo(feil);
 
             AsyncPollingStatus status = new AsyncPollingStatus(
                     AsyncPollingStatus.Status.DELAYED,

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/verge/VergeRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/verge/VergeRestTjeneste.java
@@ -87,7 +87,7 @@ public class VergeRestTjeneste {
     public Response opprettVerge(@Context HttpServletRequest request,
                                  @TilpassetAbacAttributt(supplierClass = BehandlingReferanseAbacAttributter.AbacDataBehandlingReferanse.class)
                                  @Parameter(description = "Behandling som skal få verge/fullmektig") @Valid BehandlingReferanse dto) throws URISyntaxException {
-        Behandling behandling = behandlingTjeneste.hentBehandling(dto.getBehandlingId());
+        Behandling behandling = hentBehandling(dto);
         if (behandling.erSaksbehandlingAvsluttet() || behandling.isBehandlingPåVent()) {
             throw new TekniskException("FPT-763493", String.format("Behandlingen er allerede avsluttet eller sett på vent, kan ikke opprette verge for behandling %s", behandling.getId()));
         }
@@ -113,7 +113,7 @@ public class VergeRestTjeneste {
     public Response fjernVerge(@Context HttpServletRequest request,
                                @TilpassetAbacAttributt(supplierClass = BehandlingReferanseAbacAttributter.AbacDataBehandlingReferanse.class)
                                @Parameter(description = "Behandling som skal få fjernet verge/fullmektig") @Valid BehandlingReferanse dto) throws URISyntaxException {
-        Behandling behandling = behandlingTjeneste.hentBehandling(dto.getBehandlingId());
+        Behandling behandling = hentBehandling(dto);
         if (behandling.erSaksbehandlingAvsluttet() || behandling.isBehandlingPåVent()) {
             throw new TekniskException("FPT-763494", String.format("Behandlingen er allerede avsluttet eller sett på vent, kan ikke fjerne verge for behandling %s", behandling.getId()));
         }


### PR DESCRIPTION
Redusere task-warnings til Info slik som i fpsak

Fikser verge/hentbehandling med UUID. Det fantes en metode helt nederst i klassen