### PR TITLE
Bump batik med 1.16 som har patchet flere sårbarheter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,8 +388,8 @@
                 <version>${handlebars.version}</version>
             </dependency>
 
-            <!-- Batik kommer med batik 1.14 versjon som har mange sårbarheter
-            - drar derfor 1.16 versjon inn som er patched -->
+            <!-- openhtmltopdf-svg-support kommer med batik 1.14 versjon som drar inn mange sårbarheter
+            - vi bruker derfor 1.16 versjon inn som er patched allerede -->
             <dependency>
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>batik-transcoder</artifactId>


### PR DESCRIPTION
[Snyk scan](https://app.snyk.io/org/teamforeldrepenger/reporting?context[page]=issues-detail&project_target=navikt%252Ffptilbake&project_origin=cli&issue_status=Open&issue_by=Severity&table_issues_detail_cols=SCORE%257CCVE%257CCWE%257CPROJECT%257CEXPLOIT%2520MATURITY%257CAUTO%2520FIXABLE%257CINTRODUCED%257CSNYK%2520PRODUCT&table_issues_detail_sort=%2520PRIORITY_SCORE%2520DESC)

Det er mulig å fikse mange av disse bare ved å bumpe batik til versjon 1.16 - det finnes dessverre ikke en patchet versjon av 
`com.openhtmltopdf:openhtmltopdf-svg-support` og mulig at prosjektet ble bare lagt på is også.

Bumper derfor versjonen selv i dependencyManagement til fptilbake.

Må testes om brevene får nav logo på toppen. Regner med at samme øvelse må gjøres i `dokgen` men da er det ikke kritisk siden dokgen ikke lagrer noe info om brukeren og ikke har noe data i databasen.