### PR TITLE
Returnere taskgruppe slik at polling ikke gir feil

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/ForvaltningKravgrunnlagRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/ForvaltningKravgrunnlagRestTjeneste.java
@@ -130,7 +130,7 @@ public class ForvaltningKravgrunnlagRestTjeneste {
             @ApiResponse(responseCode = "500", description = "Ukjent feil!")
         })
     @BeskyttetRessurs(actionType = ActionType.READ, property = AbacProperty.DRIFT)
-    public Response hentForvaltninginfo(@NotNull @QueryParam("saksnummer") SaksnummerDto saksnummer) {
+    public Response hentForvaltninginfo(@Valid @NotNull @QueryParam("saksnummer") SaksnummerDto saksnummer) {
         try {
             return Response.ok(forvaltningTjeneste.hentForvaltningsinfo(new Saksnummer(saksnummer.getVerdi()))).build();
         } catch (Exception e) {


### PR DESCRIPTION
Manuell gjenoppta behandling får i dag tilbake callId og polling gir valideringsfeil.
Går over til å returnere taskgruppe slik at polling virker og gjenoppta ikke gir rød strek