### PR TITLE
TFP-5553 fptilbake sender samme hendelser som fpsak

### DIFF
--- a/behandlingskontroll/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingskontroll/events/BehandlingEnhetEvent.java
+++ b/behandlingskontroll/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingskontroll/events/BehandlingEnhetEvent.java
@@ -4,16 +4,10 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandli
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.AktørId;
 
-public class BehandlingEnhetEvent implements BehandlingEvent {
-    private Long fagsakId;
-    private Long behandlingId;
-    private AktørId aktørId;
-
+public record BehandlingEnhetEvent(Long fagsakId, Long behandlingId, AktørId aktørId) implements BehandlingEvent {
 
     public BehandlingEnhetEvent(Behandling behandling) {
-        this.fagsakId = behandling.getFagsakId();
-        this.behandlingId = behandling.getId();
-        this.aktørId = behandling.getAktørId();
+        this(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId());
     }
 
     @Override

--- a/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/observer/FpLosEventObserver.java
+++ b/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/observer/FpLosEventObserver.java
@@ -1,0 +1,98 @@
+package no.nav.foreldrepenger.tilbakekreving.los.klient.observer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.events.AksjonspunktStatusEvent;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.events.BehandlingEnhetEvent;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.events.BehandlingStatusEvent;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.events.BehandlingskontrollEvent;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingEvent;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.Fagsystem;
+import no.nav.foreldrepenger.tilbakekreving.fagsystem.ApplicationName;
+import no.nav.foreldrepenger.tilbakekreving.los.klient.task.FpLosPubliserEventTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.vedtak.hendelser.behandling.Hendelse;
+
+@ApplicationScoped
+public class FpLosEventObserver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FpLosEventObserver.class);
+
+    private Fagsystem fagsystem;
+
+    private ProsessTaskTjeneste taskTjeneste;
+
+    public FpLosEventObserver() {
+    }
+
+    @Inject
+    public FpLosEventObserver(ProsessTaskTjeneste taskTjeneste) {
+        this(taskTjeneste, ApplicationName.hvilkenTilbake());
+    }
+
+    public FpLosEventObserver(ProsessTaskTjeneste taskTjeneste,
+                              Fagsystem fagsystem) {
+        this.taskTjeneste = taskTjeneste;
+        this.fagsystem = fagsystem;
+    }
+
+    public void observerStoppetEvent(@Observes BehandlingskontrollEvent.StoppetEvent event) {
+        try {
+            opprettProsessTask(event, Hendelse.AKSJONSPUNKT);
+        } catch (Exception ex) {
+            LOG.warn("Publisering av StoppetEvent feilet", ex);
+        }
+    }
+
+    // Lytter på AksjonspunkterFunnetEvent, filtrer ut når behandling er satt manuelt på vent og legger melding på kafka
+    public void observerAksjonpunktStatusEvent(@Observes AksjonspunktStatusEvent event) {
+        var sattPåVent = event.getAksjonspunkter().stream().anyMatch(e -> e.erOpprettet() && e.erAutopunkt());
+        if (sattPåVent) {
+            try {
+                opprettProsessTask(event, Hendelse.VENTETILSTAND);
+            } catch (Exception ex) {
+                LOG.warn("Publisering av AksjonspunkterFunnetEvent feilet", ex);
+            }
+        }
+    }
+
+    public void observerBehandlingAvsluttetEvent(@Observes BehandlingStatusEvent.BehandlingOpprettetEvent event) {
+        try {
+            opprettProsessTask(event, Hendelse.OPPRETTET);
+        } catch (Exception ex) {
+            LOG.warn("Publisering av BehandlingAvsluttetEvent feilet", ex);
+        }
+    }
+
+    public void observerBehandlingAvsluttetEvent(@Observes BehandlingStatusEvent.BehandlingAvsluttetEvent event) {
+        try {
+            opprettProsessTask(event, Hendelse.AVSLUTTET);
+        } catch (Exception ex) {
+            LOG.warn("Publisering av BehandlingAvsluttetEvent feilet", ex);
+        }
+    }
+
+    public void observerAksjonspunktHarEndretBehandlendeEnhetEvent(@Observes BehandlingEnhetEvent event) {
+        try {
+            opprettProsessTask(event, Hendelse.ENHET);
+        } catch (Exception ex) {
+            LOG.warn("Publisering av AksjonspunktHarEndretBehandlendeEnhetEvent feilet", ex);
+        }
+    }
+
+    private void opprettProsessTask(BehandlingEvent behandlingEvent, Hendelse hendelse) {
+        if (Fagsystem.FPTILBAKE.equals(fagsystem)) {
+            var prosessTaskData = ProsessTaskData.forProsessTask(FpLosPubliserEventTask.class);
+            prosessTaskData.setBehandling(behandlingEvent.getFagsakId(), behandlingEvent.getBehandlingId(), behandlingEvent.getAktørId().getId());
+            prosessTaskData.setProperty(FpLosPubliserEventTask.PROPERTY_EVENT_NAME, hendelse.name());
+            prosessTaskData.setCallIdFraEksisterende();
+            prosessTaskData.setPrioritet(90);
+            taskTjeneste.lagre(prosessTaskData);
+        }
+    }
+}

--- a/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/observer/K9LosEventObserver.java
+++ b/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/observer/K9LosEventObserver.java
@@ -21,16 +21,16 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.reposito
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.Fagsystem;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.AktørId;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.ApplicationName;
-import no.nav.foreldrepenger.tilbakekreving.los.klient.task.LosPubliserEventTask;
+import no.nav.foreldrepenger.tilbakekreving.los.klient.task.K9LosPubliserEventTask;
 import no.nav.vedtak.felles.integrasjon.kafka.EventHendelse;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 
 @ApplicationScoped
-public class LosEventObserver {
+public class K9LosEventObserver {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LosEventObserver.class);
+    private static final Logger LOG = LoggerFactory.getLogger(K9LosEventObserver.class);
     private static final String LOGGER_OPPRETTER_PROSESS_TASK = "Oppretter prosess task for å publisere event={} til los for aksjonspunkt={}";
 
     private Fagsystem fagsystem;
@@ -40,21 +40,21 @@ public class LosEventObserver {
 
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
 
-    LosEventObserver() {
+    K9LosEventObserver() {
         // for CDI proxy
     }
 
     @Inject
-    public LosEventObserver(BehandlingRepository behandlingRepository,
-                            ProsessTaskTjeneste taskTjeneste,
-                            BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
+    public K9LosEventObserver(BehandlingRepository behandlingRepository,
+                              ProsessTaskTjeneste taskTjeneste,
+                              BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
         this(behandlingRepository, taskTjeneste, behandlingskontrollTjeneste, ApplicationName.hvilkenTilbake());
     }
 
-    public LosEventObserver(BehandlingRepository behandlingRepository,
-                            ProsessTaskTjeneste taskTjeneste,
-                            BehandlingskontrollTjeneste behandlingskontrollTjeneste,
-                            Fagsystem fagsystem) {
+    public K9LosEventObserver(BehandlingRepository behandlingRepository,
+                              ProsessTaskTjeneste taskTjeneste,
+                              BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                              Fagsystem fagsystem) {
         this.behandlingRepository = behandlingRepository;
         this.taskTjeneste = taskTjeneste;
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
@@ -62,13 +62,7 @@ public class LosEventObserver {
     }
 
     public void observerAksjonpunktStatusEvent(@Observes AksjonspunktStatusEvent event) {
-        if (Fagsystem.FPTILBAKE.equals(fagsystem)) {
-            var sattPåVent = event.getAksjonspunkter().stream()
-                .anyMatch(e -> e.erOpprettet() && e.erAutopunkt());
-            if (sattPåVent) {
-                opprettProsessTask(event.getFagsakId(), event.getBehandlingId(), event.getAktørId(), EventHendelse.AKSJONSPUNKT_OPPRETTET);
-            }
-        } else {
+        if (!Fagsystem.FPTILBAKE.equals(fagsystem)) {
             Long behandlingId = event.getBehandlingId();
             for (Aksjonspunkt aksjonspunkt : event.getAksjonspunkter()) {
                 if (AksjonspunktStatus.OPPRETTET.equals(aksjonspunkt.getStatus()) && (aksjonspunkt.erManuell() || erBehandlingIFaktaEllerSenereSteg(
@@ -95,27 +89,20 @@ public class LosEventObserver {
     }
 
     public void observerStoppetEvent(@Observes BehandlingskontrollEvent.StoppetEvent event) {
-        if (Fagsystem.FPTILBAKE.equals(fagsystem)) {
+        if (!Fagsystem.FPTILBAKE.equals(fagsystem) && event.getStegStatus().equals(BehandlingStegStatus.INNGANG)) {
             opprettProsessTask(event.getFagsakId(), event.getBehandlingId(), event.getAktørId(), EventHendelse.BEHANDLINGSKONTROLL_EVENT);
-        } else {
-            if (event.getStegStatus().equals(BehandlingStegStatus.INNGANG)) {
-                opprettProsessTask(event.getFagsakId(), event.getBehandlingId(), event.getAktørId(), EventHendelse.BEHANDLINGSKONTROLL_EVENT);
-            }
         }
     }
 
     private void opprettProsessTask(long fagsakId, long behandlingId, AktørId aktørId, EventHendelse eventHendelse) {
-        ProsessTaskData taskData = lagFellesProsessTaskData(fagsakId, behandlingId, aktørId, eventHendelse);
-        taskTjeneste.lagre(taskData);
-    }
-
-    private ProsessTaskData lagFellesProsessTaskData(long fagsakId, long behandlingId, AktørId aktørId, EventHendelse eventHendelse) {
-        ProsessTaskData taskData = ProsessTaskData.forProsessTask(LosPubliserEventTask.class);
-        taskData.setCallIdFraEksisterende();
-        taskData.setPrioritet(50);
-        taskData.setProperty(LosPubliserEventTask.PROPERTY_EVENT_NAME, eventHendelse.name());
-        taskData.setBehandling(fagsakId, behandlingId, aktørId.getId());
-        return taskData;
+        if (!Fagsystem.FPTILBAKE.equals(fagsystem)) {
+            ProsessTaskData taskData = ProsessTaskData.forProsessTask(K9LosPubliserEventTask.class);
+            taskData.setCallIdFraEksisterende();
+            taskData.setPrioritet(50);
+            taskData.setProperty(K9LosPubliserEventTask.PROPERTY_EVENT_NAME, eventHendelse.name());
+            taskData.setBehandling(fagsakId, behandlingId, aktørId.getId());
+            taskTjeneste.lagre(taskData);
+        }
     }
 
     private boolean erBehandlingIFaktaEllerSenereSteg(Long behandlingId) {

--- a/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/FpLosPubliserEventTask.java
+++ b/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/FpLosPubliserEventTask.java
@@ -1,0 +1,122 @@
+package no.nav.foreldrepenger.tilbakekreving.los.klient.task;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.Fagsystem;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.task.ProsessTaskDataWrapper;
+import no.nav.foreldrepenger.tilbakekreving.fagsystem.ApplicationName;
+import no.nav.foreldrepenger.tilbakekreving.los.klient.producer.LosKafkaProducerAiven;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.hendelser.behandling.Behandlingstype;
+import no.nav.vedtak.hendelser.behandling.Hendelse;
+import no.nav.vedtak.hendelser.behandling.Kildesystem;
+import no.nav.vedtak.hendelser.behandling.Ytelse;
+import no.nav.vedtak.hendelser.behandling.v1.BehandlingHendelseV1;
+
+@ApplicationScoped
+@ProsessTask("fplos.oppgavebehandling.behandlingshendelse")
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false)
+public class FpLosPubliserEventTask implements ProsessTaskHandler {
+
+    public static final String PROPERTY_EVENT_NAME = "eventName";
+
+    private static final Set<Hendelse> ENDELIGE_HENDELSER = Set.of(Hendelse.OPPRETTET, Hendelse.AVSLUTTET, Hendelse.ENHET);
+
+    private Fagsystem fagsystem;
+
+    private static final Logger LOG = LoggerFactory.getLogger(FpLosPubliserEventTask.class);
+
+    private BehandlingRepository behandlingRepository;
+    private LosKafkaProducerAiven losKafkaProducerAiven;
+
+    boolean brukAiven;
+
+    FpLosPubliserEventTask() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public FpLosPubliserEventTask(BehandlingRepositoryProvider repositoryProvider,
+                                  LosKafkaProducerAiven losKafkaProducerAiven) {
+        this(repositoryProvider, losKafkaProducerAiven, ApplicationName.hvilkenTilbake());
+    }
+
+    public FpLosPubliserEventTask(BehandlingRepositoryProvider repositoryProvider,
+                                  LosKafkaProducerAiven losKafkaProducerAiven,
+                                  Fagsystem applikasjonNavn) {
+        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.losKafkaProducerAiven = losKafkaProducerAiven;
+
+        this.fagsystem = switch (applikasjonNavn) {
+            case FPTILBAKE -> Fagsystem.FPTILBAKE;
+            case K9TILBAKE -> Fagsystem.K9TILBAKE;
+            default -> throw new IllegalStateException("applikasjonsnavn er satt til " + applikasjonNavn + " som ikke er en støttet verdi");
+        };
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var behandlingId = ProsessTaskDataWrapper.wrap(prosessTaskData).getBehandlingId();
+        var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var hendelse = utledHendelse(behandling, Hendelse.valueOf(prosessTaskData.getPropertyValue(PROPERTY_EVENT_NAME)));
+        if (hendelse == null || !Fagsystem.FPTILBAKE.equals(fagsystem)) {
+            LOG.info("Publiser ikke behandlingshendelse for behandling {} hendelse {}", behandling.getId(), hendelse);
+            return;
+        }
+
+        var losHendelseDto = new BehandlingHendelseV1.Builder().medKildesystem(Kildesystem.FPTILBAKE).medHendelse(hendelse)
+            .medHendelseUuid(UUID.randomUUID())
+            .medBehandlingUuid(behandling.getUuid())
+            .medSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi())
+            .medAktørId(behandling.getAktørId().getId())
+            .medYtelse(mapYtelse(behandling))
+            .medBehandlingstype(mapBehandlingstype(behandling))
+            .medTidspunkt(LocalDateTime.now())
+            .build();
+        losKafkaProducerAiven.sendHendelseFplos(behandling.getFagsak().getSaksnummer(), losHendelseDto);
+    }
+
+    private static Ytelse mapYtelse(Behandling behandling) {
+        return switch (behandling.getFagsak().getFagsakYtelseType()) {
+            case ENGANGSTØNAD -> Ytelse.ENGANGSTØNAD;
+            case FORELDREPENGER -> Ytelse.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> Ytelse.SVANGERSKAPSPENGER;
+            default -> null;
+        };
+    }
+
+    private static Behandlingstype mapBehandlingstype(Behandling behandling) {
+        return switch (behandling.getType()) {
+            case TILBAKEKREVING -> Behandlingstype.TILBAKEBETALING;
+            case REVURDERING_TILBAKEKREVING -> Behandlingstype.TILBAKEBETALING_REVURDERING;
+            default -> null;
+        };
+    }
+
+    private static Hendelse utledHendelse(Behandling behandling, Hendelse oppgittHendelse) {
+        if (ENDELIGE_HENDELSER.contains(oppgittHendelse)) {
+            return oppgittHendelse;
+        }
+        if (behandling.isBehandlingPåVent()) {
+            return Hendelse.VENTETILSTAND;
+        } else if (!behandling.getAksjonspunkter().isEmpty()) {
+            return Hendelse.AKSJONSPUNKT;
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/K9LosPubliserEventTask.java
+++ b/integrasjontjenester/los-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/K9LosPubliserEventTask.java
@@ -7,12 +7,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import no.nav.foreldrepenger.tilbakekreving.behandling.impl.FaktaFeilutbetalingTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingStatus;
@@ -44,18 +43,16 @@ import no.nav.vedtak.hendelser.behandling.v1.BehandlingHendelseV1;
 @ApplicationScoped
 @ProsessTask("fplos.oppgavebehandling.PubliserEvent")
 @FagsakProsesstaskRekkefølge(gruppeSekvens = false)
-public class LosPubliserEventTask implements ProsessTaskHandler {
+public class K9LosPubliserEventTask implements ProsessTaskHandler {
 
     public static final String PROPERTY_EVENT_NAME = "eventName";
-    public static final String PROPERTY_KRAVGRUNNLAG_MANGLER_FRIST_TID = "kravgrunnlagManglerFristTid";
-    public static final String PROPERTY_KRAVGRUNNLAG_MANGLER_AKSJONSPUNKT_STATUS_KODE = "kravgrunnlagManglerAksjonspunktStatusKode";
     public static final String FP_DEFAULT_HREF = "/fpsak/fagsak/%s/behandling/%s/?punkt=default&fakta=default";
     public static final String K9_DEFAULT_HREF = "/k9/web/fagsak/%s/behandling/%s/?punkt=default&fakta=default";
 
     private Fagsystem fagsystem;
     private String defaultHRef;
 
-    private static final Logger LOG = LoggerFactory.getLogger(LosPubliserEventTask.class);
+    private static final Logger LOG = LoggerFactory.getLogger(K9LosPubliserEventTask.class);
 
     private KravgrunnlagRepository grunnlagRepository;
     private BehandlingRepository behandlingRepository;
@@ -64,21 +61,21 @@ public class LosPubliserEventTask implements ProsessTaskHandler {
 
     boolean brukAiven;
 
-    LosPubliserEventTask() {
+    K9LosPubliserEventTask() {
         // for CDI proxy
     }
 
     @Inject
-    public LosPubliserEventTask(BehandlingRepositoryProvider repositoryProvider,
-                                FaktaFeilutbetalingTjeneste faktaFeilutbetalingTjeneste,
-                                LosKafkaProducerAiven losKafkaProducerAiven) {
+    public K9LosPubliserEventTask(BehandlingRepositoryProvider repositoryProvider,
+                                  FaktaFeilutbetalingTjeneste faktaFeilutbetalingTjeneste,
+                                  LosKafkaProducerAiven losKafkaProducerAiven) {
         this(repositoryProvider, faktaFeilutbetalingTjeneste, losKafkaProducerAiven, ApplicationName.hvilkenTilbake());
     }
 
-    public LosPubliserEventTask(BehandlingRepositoryProvider repositoryProvider,
-                                FaktaFeilutbetalingTjeneste faktaFeilutbetalingTjeneste,
-                                LosKafkaProducerAiven losKafkaProducerAiven,
-                                Fagsystem applikasjonNavn) {
+    public K9LosPubliserEventTask(BehandlingRepositoryProvider repositoryProvider,
+                                  FaktaFeilutbetalingTjeneste faktaFeilutbetalingTjeneste,
+                                  LosKafkaProducerAiven losKafkaProducerAiven,
+                                  Fagsystem applikasjonNavn) {
         this.grunnlagRepository = repositoryProvider.getGrunnlagRepository();
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.faktaFeilutbetalingTjeneste = faktaFeilutbetalingTjeneste;

--- a/integrasjontjenester/los-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/los/klient/observer/K9LosEventObserverTest.java
+++ b/integrasjontjenester/los-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/los/klient/observer/K9LosEventObserverTest.java
@@ -8,14 +8,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
 
-import jakarta.persistence.EntityManager;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import jakarta.persistence.EntityManager;
 import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.events.AksjonspunktStatusEvent;
 import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.events.BehandlingEnhetEvent;
@@ -33,20 +32,20 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.reposito
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.Fagsystem;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.testutilities.kodeverk.ScenarioSimple;
 import no.nav.foreldrepenger.tilbakekreving.dbstoette.JpaExtension;
-import no.nav.foreldrepenger.tilbakekreving.los.klient.task.LosPubliserEventTask;
+import no.nav.foreldrepenger.tilbakekreving.los.klient.task.K9LosPubliserEventTask;
 import no.nav.vedtak.felles.integrasjon.kafka.EventHendelse;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 
 @ExtendWith(JpaExtension.class)
-class LosEventObserverTest {
+class K9LosEventObserverTest {
 
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
 
     private ProsessTaskTjeneste taskTjeneste;
 
-    private LosEventObserver losEventObserver;
+    private K9LosEventObserver losEventObserver;
 
     private Behandling behandling;
     private BehandlingskontrollKontekst behandlingskontrollKontekst;
@@ -57,7 +56,7 @@ class LosEventObserverTest {
         taskTjeneste = Mockito.mock(ProsessTaskTjeneste.class);
         behandlingskontrollTjeneste = new BehandlingskontrollTjeneste(new BehandlingskontrollServiceProvider(entityManager,
                 new BehandlingModellRepository(), mock(BehandlingskontrollEventPubliserer.class)));
-        losEventObserver = new LosEventObserver(repositoryProvider.getBehandlingRepository(),
+        losEventObserver = new K9LosEventObserver(repositoryProvider.getBehandlingRepository(),
                 taskTjeneste, behandlingskontrollTjeneste, Fagsystem.K9TILBAKE);
 
         behandling = ScenarioSimple.simple().lagre(repositoryProvider);
@@ -179,8 +178,8 @@ class LosEventObserverTest {
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
         verify(taskTjeneste, times(1)).lagre(captor.capture());
         var publisherEventProsessTask = captor.getValue();
-        assertThat(publisherEventProsessTask.taskType()).isEqualTo(TaskType.forProsessTask(LosPubliserEventTask.class));
-        assertThat(publisherEventProsessTask.getPropertyValue(LosPubliserEventTask.PROPERTY_EVENT_NAME)).isEqualTo(eventHendelse.name());
+        assertThat(publisherEventProsessTask.taskType()).isEqualTo(TaskType.forProsessTask(K9LosPubliserEventTask.class));
+        assertThat(publisherEventProsessTask.getPropertyValue(K9LosPubliserEventTask.PROPERTY_EVENT_NAME)).isEqualTo(eventHendelse.name());
         return publisherEventProsessTask;
     }
 }

--- a/integrasjontjenester/los-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/FpLosPubliserEventTaskAivenTest.java
+++ b/integrasjontjenester/los-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/FpLosPubliserEventTaskAivenTest.java
@@ -1,0 +1,126 @@
+package no.nav.foreldrepenger.tilbakekreving.los.klient.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import jakarta.persistence.EntityManager;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.impl.BehandlingModellRepository;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.impl.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.Fagsystem;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.testutilities.kodeverk.ScenarioSimple;
+import no.nav.foreldrepenger.tilbakekreving.dbstoette.JpaExtension;
+import no.nav.foreldrepenger.tilbakekreving.los.klient.producer.LosKafkaProducerAiven;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.hendelser.behandling.Behandlingstype;
+import no.nav.vedtak.hendelser.behandling.Hendelse;
+import no.nav.vedtak.hendelser.behandling.Kildesystem;
+import no.nav.vedtak.hendelser.behandling.Ytelse;
+import no.nav.vedtak.hendelser.behandling.v1.BehandlingHendelseV1;
+
+@ExtendWith(JpaExtension.class)
+class FpLosPubliserEventTaskAivenTest {
+
+    private BehandlingRepositoryProvider repositoryProvider;
+
+    private LosKafkaProducerAiven mockKafkaProducerAiven = mock(LosKafkaProducerAiven.class);
+
+    private FpLosPubliserEventTask losPubliserEventTask;
+
+    private Behandling behandling;
+    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+
+    @BeforeEach
+    void setup(EntityManager entityManager) {
+        repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        behandlingskontrollTjeneste = new BehandlingskontrollTjeneste(new BehandlingskontrollServiceProvider(entityManager, new BehandlingModellRepository(), null));
+        losPubliserEventTask = new FpLosPubliserEventTask(repositoryProvider, mockKafkaProducerAiven, Fagsystem.FPTILBAKE);
+
+        behandling = ScenarioSimple.simple().lagre(repositoryProvider);
+    }
+
+    @Test
+    void skal_publisere_fplos_data_til_kafka() {
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst, List.of(AksjonspunktDefinisjon.VENT_PÅ_BRUKERTILBAKEMELDING, AksjonspunktDefinisjon.AVKLART_FAKTA_FEILUTBETALING));
+
+        var prosessTaskData = lagProsessTaskData(Hendelse.VENTETILSTAND);
+        losPubliserEventTask.doTask(prosessTaskData);
+
+        var eventCaptor = ArgumentCaptor.forClass(BehandlingHendelseV1.class);
+        verify(mockKafkaProducerAiven, atLeastOnce()).sendHendelseFplos(any(), eventCaptor.capture());
+        var event = eventCaptor.getValue();
+
+
+        assertThat(event.getHendelse()).isEqualTo(Hendelse.VENTETILSTAND);
+        assertThat(event.getKildesystem()).isEqualTo(Kildesystem.FPTILBAKE);
+        assertThat(event.getBehandlingUuid()).isEqualTo(behandling.getUuid());
+        assertThat(event.getAktørId().getAktørId()).isEqualTo(behandling.getAktørId().getId());
+        assertThat(event.getYtelse()).isEqualTo(Ytelse.FORELDREPENGER);
+        assertThat(event.getBehandlingstype()).isEqualTo(Behandlingstype.TILBAKEBETALING);
+    }
+
+
+    @Test
+    void skal_publisere_fplos_data_til_kafka_for_henleggelse_når_kravgrunnlag_ikke_finnes() {
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst, BehandlingStegType.FAKTA_FEILUTBETALING, List.of(AksjonspunktDefinisjon.AVKLART_FAKTA_FEILUTBETALING));
+
+        var prosessTaskData = lagProsessTaskData(Hendelse.AKSJONSPUNKT);
+        losPubliserEventTask.doTask(prosessTaskData);
+
+        var eventCaptor = ArgumentCaptor.forClass(BehandlingHendelseV1.class);
+        verify(mockKafkaProducerAiven, atLeastOnce()).sendHendelseFplos(any(), eventCaptor.capture());
+        var event = eventCaptor.getValue();
+
+
+        assertThat(event.getHendelse()).isEqualTo(Hendelse.AKSJONSPUNKT);
+        assertThat(event.getKildesystem()).isEqualTo(Kildesystem.FPTILBAKE);
+        assertThat(event.getBehandlingUuid()).isEqualTo(behandling.getUuid());
+        assertThat(event.getAktørId().getAktørId()).isEqualTo(behandling.getAktørId().getId());
+        assertThat(event.getYtelse()).isEqualTo(Ytelse.FORELDREPENGER);
+        assertThat(event.getBehandlingstype()).isEqualTo(Behandlingstype.TILBAKEBETALING);
+
+    }
+
+    @Test
+    void skal_publisere_fplos_data_til_kafka_for_opprettet_behandling() {
+        var prosessTaskData = lagProsessTaskData(Hendelse.OPPRETTET);
+        losPubliserEventTask.doTask(prosessTaskData);
+
+        var eventCaptor = ArgumentCaptor.forClass(BehandlingHendelseV1.class);
+        verify(mockKafkaProducerAiven, atLeastOnce()).sendHendelseFplos(any(), eventCaptor.capture());
+        var event = eventCaptor.getValue();
+
+        assertThat(event.getHendelse()).isEqualTo(Hendelse.OPPRETTET);
+        assertThat(event.getKildesystem()).isEqualTo(Kildesystem.FPTILBAKE);
+        assertThat(event.getBehandlingUuid()).isEqualTo(behandling.getUuid());
+        assertThat(event.getAktørId().getAktørId()).isEqualTo(behandling.getAktørId().getId());
+        assertThat(event.getYtelse()).isEqualTo(Ytelse.FORELDREPENGER);
+        assertThat(event.getBehandlingstype()).isEqualTo(Behandlingstype.TILBAKEBETALING);
+
+    }
+
+
+    private ProsessTaskData lagProsessTaskData(Hendelse hendelse) {
+        var prosessTaskData = ProsessTaskData.forProsessTask(FpLosPubliserEventTask.class);
+        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setProperty(FpLosPubliserEventTask.PROPERTY_EVENT_NAME, hendelse.name());
+        return prosessTaskData;
+    }
+
+}

--- a/integrasjontjenester/los-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/K9LosPubliserEventTaskAivenTest.java
+++ b/integrasjontjenester/los-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/los/klient/task/K9LosPubliserEventTaskAivenTest.java
@@ -56,7 +56,7 @@ import no.nav.vedtak.felles.integrasjon.kafka.TilbakebetalingBehandlingProsessEv
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
 @ExtendWith(JpaExtension.class)
-class LosPubliserEventTaskAivenTest {
+class K9LosPubliserEventTaskAivenTest {
 
     private static final LocalDate FOM_1 = LocalDate.of(2019, 12, 1);
     private static final LocalDate TOM_1 = LocalDate.of(2019, 12, 31);
@@ -68,7 +68,7 @@ class LosPubliserEventTaskAivenTest {
 
     private LosKafkaProducerAiven mockKafkaProducerAiven = mock(LosKafkaProducerAiven.class);
 
-    private LosPubliserEventTask losPubliserEventTask;
+    private K9LosPubliserEventTask losPubliserEventTask;
 
     private Behandling behandling;
     private ProsessTaskData prosessTaskData;
@@ -86,7 +86,7 @@ class LosPubliserEventTaskAivenTest {
                 mockGjenopptaBehandlingTjeneste, mockBehandlingskontrollTjeneste, mockEventPubliserer, mock(AutomatiskSaksbehandlingVurderingTjeneste.class), entityManager);
         FaktaFeilutbetalingTjeneste faktaFeilutbetalingTjeneste = new FaktaFeilutbetalingTjeneste(repositoryProvider,
                 kravgrunnlagTjeneste, mockFagsystemKlient);
-        losPubliserEventTask = new LosPubliserEventTask(repositoryProvider, faktaFeilutbetalingTjeneste, mockKafkaProducerAiven, Fagsystem.K9TILBAKE);
+        losPubliserEventTask = new K9LosPubliserEventTask(repositoryProvider, faktaFeilutbetalingTjeneste, mockKafkaProducerAiven, Fagsystem.K9TILBAKE);
 
         behandling = ScenarioSimple.simple().lagre(repositoryProvider);
         behandling.setAnsvarligSaksbehandler("1234");
@@ -176,9 +176,9 @@ class LosPubliserEventTaskAivenTest {
     }
 
     private ProsessTaskData lagProsessTaskData() {
-        prosessTaskData = ProsessTaskData.forProsessTask(LosPubliserEventTask.class);
+        prosessTaskData = ProsessTaskData.forProsessTask(K9LosPubliserEventTask.class);
         prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
-        prosessTaskData.setProperty(LosPubliserEventTask.PROPERTY_EVENT_NAME, EventHendelse.AKSJONSPUNKT_OPPRETTET.name());
+        prosessTaskData.setProperty(K9LosPubliserEventTask.PROPERTY_EVENT_NAME, EventHendelse.AKSJONSPUNKT_OPPRETTET.name());
         return prosessTaskData;
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/AvhengigheterTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/AvhengigheterTest.java
@@ -1,14 +1,14 @@
 package no.nav.foreldrepenger.tilbakekreving.web.server.jetty;
 
-import jakarta.enterprise.inject.spi.CDI;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import jakarta.enterprise.inject.spi.CDI;
 import no.nav.foreldrepenger.tilbakekreving.avstemming.AvstemFraResultatOgIverksettingStatusTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.datavarehus.saksstatistikk.SakshendelserEventObserver;
 import no.nav.foreldrepenger.tilbakekreving.kravgrunnlag.queue.consumer.KravgrunnlagAsyncJmsConsumer;
-import no.nav.foreldrepenger.tilbakekreving.los.klient.observer.LosEventObserver;
+import no.nav.foreldrepenger.tilbakekreving.los.klient.observer.FpLosEventObserver;
+import no.nav.foreldrepenger.tilbakekreving.los.klient.observer.K9LosEventObserver;
 import no.nav.vedtak.felles.testutilities.cdi.WeldContext;
 
 class AvhengigheterTest {
@@ -22,7 +22,8 @@ class AvhengigheterTest {
         //har test for dette, siden dersom avhengighetene blir borte, er det ikke sikkert at det umiddelbart oppdages
 
         Assertions.assertThat(CDI.current().select(SakshendelserEventObserver.class).isResolvable()).isTrue();
-        Assertions.assertThat(CDI.current().select(LosEventObserver.class).isResolvable()).isTrue();
+        Assertions.assertThat(CDI.current().select(FpLosEventObserver.class).isResolvable()).isTrue();
+        Assertions.assertThat(CDI.current().select(K9LosEventObserver.class).isResolvable()).isTrue();
         Assertions.assertThat(CDI.current().select(KravgrunnlagAsyncJmsConsumer.class).isResolvable()).isTrue();
         Assertions.assertThat(CDI.current().select(AvstemFraResultatOgIverksettingStatusTjeneste.class).isResolvable()).isTrue();
     }


### PR DESCRIPTION
Skiller LOS-observer og publiseringtask for FPtilbake og K9tilbake så koden blir greiere.
Legger om til å sende behandling-hendelse slik som fpsak (samme logikk). Trenger at @palfi sjekker at oversikt takler det
Steg2: Forenkle K9LosPubliserEventTask (fjerne fptilbake)
