### PR TITLE
TFP-5599 enkleste tilfelle vedtak uten varsel på åpen TBK er noop

### DIFF
--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/FaktaFeilutbetalingTjenesteTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/FaktaFeilutbetalingTjenesteTest.java
@@ -208,7 +208,7 @@ class FaktaFeilutbetalingTjenesteTest extends FellesTestOppsett {
         assertThat(fakta.getTotalPeriodeTom()).isEqualTo(TOM);
         assertThat(fakta.getPerioder()).isNotEmpty();
         assertThat(fakta.getDatoForRevurderingsvedtak()).isEqualTo(NOW);
-        assertThat(fakta.getTilbakekrevingValg().getVidereBehandling()).isEqualToComparingFieldByField(VidereBehandling.TILBAKEKR_OPPRETT);
+        assertThat(fakta.getTilbakekrevingValg().videreBehandling()).isEqualToComparingFieldByField(VidereBehandling.TILBAKEKR_OPPRETT);
     }
 
     private EksternBehandlingsinfoDto lagEksternBehandlingsInfo() {

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/Tillegsinformasjon.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/Tillegsinformasjon.java
@@ -4,6 +4,7 @@ public enum Tillegsinformasjon {
     PERSONOPPLYSNINGER("personopplysninger-tilbake", "soeker-personopplysninger"),
     VARSELTEKST("tilbakekrevingsvarsel-fritekst"),
     SØKNAD("soknad-backend"),
+    SENDTOPPDRAG("oppdrag-info"),
     TILBAKEKREVINGSVALG("tilbakekreving-valg", "tilbakekrevingvalg"),
     FAGSAK("fagsak", "fagsak"),
     VERGE("verge-backend", "verge");

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SamletEksternBehandlingInfo.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SamletEksternBehandlingInfo.java
@@ -24,7 +24,7 @@ public class SamletEksternBehandlingInfo {
     private SoknadDto søknad;
     private FagsakDto fagsak;
     private VergeDto verge;
-    private SendtoppdragDto sendtoppdrag;
+    private Boolean sendtoppdrag;
 
     public EksternBehandlingsinfoDto getGrunninformasjon() {
         return grunninformasjon;
@@ -40,7 +40,7 @@ public class SamletEksternBehandlingInfo {
         return varseltekst;
     }
 
-    public SendtoppdragDto getSendtoppdrag() {
+    public Boolean getSendtoppdrag() {
         check(tilleggsinformasjonHentet.contains(Tillegsinformasjon.SENDTOPPDRAG), "Utvikler-feil: har ikke hentet sendt oppdrag");
         return sendtoppdrag;
     }
@@ -117,7 +117,7 @@ public class SamletEksternBehandlingInfo {
             return this;
         }
 
-        public Builder setSendtoppdrag(SendtoppdragDto sendtoppdrag) {
+        public Builder setSendtoppdrag(Boolean sendtoppdrag) {
             kladd.sendtoppdrag = sendtoppdrag;
             return this;
         }

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SamletEksternBehandlingInfo.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SamletEksternBehandlingInfo.java
@@ -24,6 +24,7 @@ public class SamletEksternBehandlingInfo {
     private SoknadDto søknad;
     private FagsakDto fagsak;
     private VergeDto verge;
+    private SendtoppdragDto sendtoppdrag;
 
     public EksternBehandlingsinfoDto getGrunninformasjon() {
         return grunninformasjon;
@@ -37,6 +38,11 @@ public class SamletEksternBehandlingInfo {
     public String getVarseltekst() {
         check(tilleggsinformasjonHentet.contains(Tillegsinformasjon.VARSELTEKST), "Utvikler-feil: har ikke hentet varseltekst");
         return varseltekst;
+    }
+
+    public SendtoppdragDto getSendtoppdrag() {
+        check(tilleggsinformasjonHentet.contains(Tillegsinformasjon.SENDTOPPDRAG), "Utvikler-feil: har ikke hentet sendt oppdrag");
+        return sendtoppdrag;
     }
 
     public TilbakekrevingValgDto getTilbakekrevingsvalg() {
@@ -111,6 +117,11 @@ public class SamletEksternBehandlingInfo {
             return this;
         }
 
+        public Builder setSendtoppdrag(SendtoppdragDto sendtoppdrag) {
+            kladd.sendtoppdrag = sendtoppdrag;
+            return this;
+        }
+
         public Builder setVarseltekst(VarseltekstDto varseltekst) {
             kladd.varseltekst = varseltekst.getVarseltekst();
             return this;
@@ -143,6 +154,7 @@ public class SamletEksternBehandlingInfo {
             valider(Tillegsinformasjon.SØKNAD, SamletEksternBehandlingInfo::getSøknad);
             valider(Tillegsinformasjon.VERGE, SamletEksternBehandlingInfo::getVerge);
             valider(Tillegsinformasjon.VARSELTEKST, SamletEksternBehandlingInfo::getVarseltekst);
+            valider(Tillegsinformasjon.SENDTOPPDRAG, SamletEksternBehandlingInfo::getSendtoppdrag);
             return kladd;
         }
 

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SendtoppdragDto.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SendtoppdragDto.java
@@ -1,4 +1,3 @@
 package no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto;
 
-public record SendtoppdragDto(String saksnummer, Long behandlingId) {
-}
+public record SendtoppdragDto(String saksnummer) {}

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SendtoppdragDto.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SendtoppdragDto.java
@@ -1,0 +1,4 @@
+package no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto;
+
+public record SendtoppdragDto(String saksnummer, Long behandlingId) {
+}

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/TilbakekrevingValgDto.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/TilbakekrevingValgDto.java
@@ -2,23 +2,6 @@ package no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto;
 
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.tilbakekrevingsvalg.VidereBehandling;
 
-public class TilbakekrevingValgDto {
-
-    private VidereBehandling videreBehandling;
-
-    public TilbakekrevingValgDto() {
-    }
-
-    public TilbakekrevingValgDto(VidereBehandling videreBehandling) {
-        this.videreBehandling = videreBehandling;
-    }
-
-    public VidereBehandling getVidereBehandling() {
-        return videreBehandling;
-    }
-
-    public boolean harTilbakekrevingValg() {
-        return videreBehandling != null;
-    }
+public record TilbakekrevingValgDto(VidereBehandling videreBehandling) {
 
 }

--- a/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlient.java
+++ b/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlient.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.UriBuilder;
+
 import no.nav.foreldrepenger.kontrakter.simulering.resultat.v1.FeilutbetaltePerioderDto;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.Henvisning;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.Fptilbake;
@@ -20,6 +21,7 @@ import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandli
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.FagsakDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.PersonopplysningDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SamletEksternBehandlingInfo;
+import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SendtoppdragDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SoknadDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.TilbakekrevingValgDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.VarseltekstDto;
@@ -88,6 +90,9 @@ public class FpsakKlient implements FagsystemKlient {
                 }
                 if (tilleggsinformasjon.contains(Tillegsinformasjon.VARSELTEKST) && lenke.getRel().equals(Tillegsinformasjon.VARSELTEKST.getFpsakRelasjonNavn())) {
                     hentVarseltekst(lenke).ifPresent(builder::setVarseltekst);
+                }
+                if (tilleggsinformasjon.contains(Tillegsinformasjon.SENDTOPPDRAG) && lenke.getRel().equals(Tillegsinformasjon.SENDTOPPDRAG.getFpsakRelasjonNavn())) {
+                    hentSendtoppdrag(lenke).ifPresent(builder::setSendtoppdrag);
                 }
                 if (tilleggsinformasjon.contains(Tillegsinformasjon.SØKNAD) && lenke.getRel().equals(Tillegsinformasjon.SØKNAD.getFpsakRelasjonNavn())) {
                     builder.setFamiliehendelse(hentSøknad(lenke));
@@ -182,6 +187,11 @@ public class FpsakKlient implements FagsystemKlient {
         URI endpoint = endpointFraLink(resourceLink);
         return get(endpoint, VarseltekstDto.class);
 
+    }
+
+    private Optional<SendtoppdragDto> hentSendtoppdrag(BehandlingResourceLinkDto resourceLink) {
+        URI endpoint = endpointFraLink(resourceLink);
+        return get(endpoint, SendtoppdragDto.class);
     }
 
     private SoknadDto hentSøknad(BehandlingResourceLinkDto resourceLink) {

--- a/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlient.java
+++ b/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlient.java
@@ -92,7 +92,7 @@ public class FpsakKlient implements FagsystemKlient {
                     hentVarseltekst(lenke).ifPresent(builder::setVarseltekst);
                 }
                 if (tilleggsinformasjon.contains(Tillegsinformasjon.SENDTOPPDRAG) && lenke.getRel().equals(Tillegsinformasjon.SENDTOPPDRAG.getFpsakRelasjonNavn())) {
-                    hentSendtoppdrag(lenke).ifPresent(builder::setSendtoppdrag);
+                    builder.setSendtoppdrag(hentSendtoppdrag(lenke).isPresent());
                 }
                 if (tilleggsinformasjon.contains(Tillegsinformasjon.SØKNAD) && lenke.getRel().equals(Tillegsinformasjon.SØKNAD.getFpsakRelasjonNavn())) {
                     builder.setFamiliehendelse(hentSøknad(lenke));

--- a/integrasjontjenester/fpsak-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlientTest.java
+++ b/integrasjontjenester/fpsak-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlientTest.java
@@ -87,7 +87,7 @@ class FpsakKlientTest {
 
         Optional<TilbakekrevingValgDto> valgDto = klient.hentTilbakekrevingValg(BEHANDLING_UUID);
         assertThat(valgDto).isPresent();
-        assertThat(valgDto.get().getVidereBehandling()).isEqualByComparingTo(VidereBehandling.TILBAKEKR_OPPRETT);
+        assertThat(valgDto.get().videreBehandling()).isEqualByComparingTo(VidereBehandling.TILBAKEKR_OPPRETT);
     }
 
     @Test

--- a/integrasjontjenester/k9-sak-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/k9sak/klient/K9sakKlientTest.java
+++ b/integrasjontjenester/k9-sak-klient/src/test/java/no/nav/foreldrepenger/tilbakekreving/k9sak/klient/K9sakKlientTest.java
@@ -85,7 +85,7 @@ class K9sakKlientTest {
 
         Optional<TilbakekrevingValgDto> valgDto = klient.hentTilbakekrevingValg(BEHANDLING_UUID);
         assertThat(valgDto).isPresent();
-        assertThat(valgDto.get().getVidereBehandling()).isEqualByComparingTo(VidereBehandling.TILBAKEKR_OPPRETT);
+        assertThat(valgDto.get().videreBehandling()).isEqualByComparingTo(VidereBehandling.TILBAKEKR_OPPRETT);
     }
 
     @Test

--- a/integrasjontjenester/ytelsesvedtak-kafka-poller/src/main/java/no/nav/foreldrepenger/tilbakekreving/hendelser/HendelseHåndtererTjeneste.java
+++ b/integrasjontjenester/ytelsesvedtak-kafka-poller/src/main/java/no/nav/foreldrepenger/tilbakekreving/hendelser/HendelseHåndtererTjeneste.java
@@ -4,6 +4,7 @@ import static java.time.temporal.TemporalAdjusters.next;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -30,7 +31,6 @@ import no.nav.foreldrepenger.tilbakekreving.domene.typer.Henvisning;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.FagsystemKlient;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.Tillegsinformasjon;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingsinfoDto;
-import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SendtoppdragDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.TilbakekrevingValgDto;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -91,11 +91,12 @@ public class HendelseHåndtererTjeneste {
         }
     }
 
-    private void settÅpenTilbakekrevingPåVent(Behandling åpenTilbakekreving, SendtoppdragDto oppdrag) {
-        if (åpenTilbakekreving != null && oppdrag != null) {
+    private void settÅpenTilbakekrevingPåVent(Behandling åpenTilbakekreving, Boolean sendtOppdrag) {
+        if (åpenTilbakekreving != null && !Objects.equals(sendtOppdrag, Boolean.FALSE)) {
             // For å redusere risiko for at det fattes vedtak basert på gammelt kravgrunnlag
             // Nytt ytelsesvedtak når det finnes åpen tilbakekreving vil ofte føre til at kravgrunnlag sperres samme kveld
             // Gjenoppta-batch kjører hverdager kl 07:00. Hvis helg, vent til tirsdag morgen, ellers 24 timer.
+            // Statusendringer for vedtak gjort en fredag kommer gjerne fredag kveld rundt kl 23.
             var idag = LocalDate.now();
             var venteTid = idag.getDayOfWeek().getValue() > DayOfWeek.FRIDAY.getValue() ?
                 idag.with(next(DayOfWeek.TUESDAY)) : idag.plusDays(1);

--- a/integrasjontjenester/ytelsesvedtak-kafka-poller/src/main/java/no/nav/foreldrepenger/tilbakekreving/hendelser/HendelseHåndtererTjeneste.java
+++ b/integrasjontjenester/ytelsesvedtak-kafka-poller/src/main/java/no/nav/foreldrepenger/tilbakekreving/hendelser/HendelseHåndtererTjeneste.java
@@ -80,9 +80,8 @@ public class HendelseHåndtererTjeneste {
             .map(TilbakekrevingValgDto::videreBehandling).orElse(null);
         var åpenTilbakekreving = behandlingRepository.finnÅpenTilbakekrevingsbehandling(hendelseTaskDataWrapper.getSaksnummer()).orElse(null);
 
+        LOG.info("Behandle VedtakHendelse {} for henvisning={} fra {}", tbkVidereBehandling, henvisning, kaller);
         if (åpenTilbakekreving == null && oppretteTilbakekreving(tbkVidereBehandling)) {
-            LOG.info("Mottatt VedtakHendelse {} er relevant for tilbakekreving opprett for henvisning={} fra {}", tbkVidereBehandling, henvisning,
-                kaller);
             lagOpprettBehandlingTask(hendelseTaskDataWrapper, henvisning);
         } else if (åpenTilbakekreving != null && oppretteTilbakekreving(tbkVidereBehandling) && nyttVarsel(samletBehandlingInfo.getVarseltekst())) {
             // Brute-force rewind slik at det sendes nytt varsel (og man venter på grunnlag)
@@ -141,8 +140,8 @@ public class HendelseHåndtererTjeneste {
 
         var harSendtVarselTidligere = brevSporingRepository.harVarselBrevSendtForBehandlingId(åpenTilbakekreving.getId());
         var loggVarsel = harSendtVarselTidligere ? "er varslet tidligere" : "ikke er varslet";
-        LOG.info("Mottatt VedtakHendelse Opprett Tilbakekreving for behandling {} har bedt om varsel og det finnes åpen tilbakekreving {} som {}",
-            eksternBehandlingUuid.toString(), åpenTilbakekreving.getId(), loggVarsel);
+        LOG.info("Behandle VedtakHendelse Opprett Tilbakekreving m/varsel i henvisning={} åpen tilbakekreving {} som {}",
+            henvisning, åpenTilbakekreving.getId(), loggVarsel);
 
         EksternBehandling eksternBehandling = new EksternBehandling(åpenTilbakekreving, henvisning, eksternBehandlingUuid);
         eksternBehandlingRepository.lagre(eksternBehandling);

--- a/integrasjontjenester/ytelsesvedtak-kafka-poller/src/main/java/no/nav/foreldrepenger/tilbakekreving/hendelser/HendelseHåndtererTjeneste.java
+++ b/integrasjontjenester/ytelsesvedtak-kafka-poller/src/main/java/no/nav/foreldrepenger/tilbakekreving/hendelser/HendelseHåndtererTjeneste.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.tilbakekreving.hendelser;
 
+import java.time.LocalDateTime;
 import static java.time.temporal.TemporalAdjusters.next;
 
 import java.time.DayOfWeek;
@@ -13,10 +14,15 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import no.nav.foreldrepenger.tilbakekreving.behandling.task.HendelseTaskDataWrapper;
 import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.impl.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.task.FortsettBehandlingTask;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.tilbakekreving.behandlingskontroll.impl.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.brev.BrevSporingRepository;
+import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.ekstern.EksternBehandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.EksternBehandlingRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.tilbakekrevingsvalg.VidereBehandling;
@@ -25,6 +31,8 @@ import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.FagsystemKlient;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.Tillegsinformasjon;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingsinfoDto;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.TilbakekrevingValgDto;
+import no.nav.foreldrepenger.tilbakekreving.felles.Frister;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ApplicationScoped
@@ -50,7 +58,6 @@ public class HendelseHåndtererTjeneste {
                                      BehandlingRepository behandlingRepository,
                                      BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                                      BrevSporingRepository brevSporingRepository) {
-
         this.taskTjeneste = taskTjeneste;
         this.fagsystemKlient = fagsystemKlient;
         this.behandlingRepository = behandlingRepository;
@@ -58,7 +65,6 @@ public class HendelseHåndtererTjeneste {
         this.brevSporingRepository = brevSporingRepository;
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
     }
-
 
     public void håndterHendelse(HendelseTaskDataWrapper hendelseTaskDataWrapper, Henvisning henvisning, String kaller) {
         var eksternBehandlingUuid = hendelseTaskDataWrapper.getBehandlingUuid();
@@ -75,31 +81,41 @@ public class HendelseHåndtererTjeneste {
             behandlingskontrollTjeneste.settBehandlingPåVentUtenSteg(åpenTilbakekreving, AksjonspunktDefinisjon.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG,
                 venteTid.atStartOfDay(), Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG);
         }
+        var harSendtVarselTidligere = åpenTilbakekreving != null && brevSporingRepository.harVarselBrevSendtForBehandlingId(åpenTilbakekreving.getId());
         if (erRelevantHendelseForOpprettTilbakekreving(tbkData)) {
-            if (åpenTilbakekreving != null) {
-                // TODO TFP-5599 - burde vi satt evt åpen TBK på vent? Eller er det så kort tid før det kommer noe fra OS at det ikke er et problem?
-                if  (samletBehandlingInfo.getVarseltekst() == null || samletBehandlingInfo.getVarseltekst().isBlank()) {
-                    // Do nothing. Det skal ikke sendes varsel å spiller liten rolle om det er sendt tidligere varsel eller ikke
-                    return;
-                } else {
-                    var harSendtVarselTidligere = brevSporingRepository.harVarselBrevSendtForBehandlingId(åpenTilbakekreving.getId()) ?
-                        "er varslet tidligere" : "ikke er varslet";
-                    LOG.info("Mottatt VedtakHendelse {} har bedt om varsel og det finnes åpen tilbakekreving som {}", tbkData.getVidereBehandling(), harSendtVarselTidligere);
-                }
-            }
-            // TODO TFP-5599 vurdere else-logikk her
             if (eksternBehandlingRepository.harEksternBehandlingForEksternUuid(eksternBehandlingUuid)) {
                 LOG.info("Mottatt VedtakHendelse {} allerede opprettet tilbakekreving for henvisning={} fra {}", tbkData.getVidereBehandling(), henvisning, kaller);
+            }
+            // Håndter åpen TBK eller opprett ny.
+            if (åpenTilbakekreving != null) {
+                // Enten vent på nytt grunnlag / ny status - eller start på nytt med nytt varselbrev
+                if  (samletBehandlingInfo.getVarseltekst() == null || samletBehandlingInfo.getVarseltekst().isBlank()) {
+                    // Det skal ikke sendes varsel og spiller liten rolle om det er sendt tidligere varsel eller ikke.
+                    // TODO TFP-5599 riktig å sette på vent?
+                    behandlingskontrollTjeneste.settBehandlingPåVentUtenSteg(åpenTilbakekreving, AksjonspunktDefinisjon.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG,
+                        LocalDateTime.now().plus(Frister.KRAVGRUNNLAG_FØRSTE), Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG);
+                } else {
+                    var loggVarsel = harSendtVarselTidligere ? "er varslet tidligere" : "ikke er varslet";
+                    LOG.info("Mottatt VedtakHendelse {} har bedt om varsel og det finnes åpen tilbakekreving som {}", tbkData.getVidereBehandling(), loggVarsel);
+                    // Brute-force rewind slik at det sendes nytt varsel (og man venter på grunnlag)
+                    rewindTilbakekrevingTilStart(åpenTilbakekreving, henvisning, eksternBehandlingUuid);
+                }
             } else {
-                LOG.info("Mottatt VedtakHendelse {} er relevant for tilbakekreving opprett for henvisning={} fra {}", tbkData.getVidereBehandling(), henvisning, kaller);
+                LOG.info("Mottatt VedtakHendelse {} er relevant for tilbakekreving opprett for henvisning={} fra {}", tbkData.getVidereBehandling(),
+                    henvisning, kaller);
                 lagOpprettBehandlingTask(hendelseTaskDataWrapper, henvisning);
             }
         } else if (erRelevantHendelseForOppdatereTilbakekreving(tbkData)) {
-            // TODO TFP-5599 - burde denne satt evt åpen TBK på vent? Eller er det så kort tid før det kommer noe fra OS at det ikke er et problem?
-            LOG.info("Mottatt VedtakHendelse {} for henvisning={} var tidligere relevant for å oppdatere behandling. Nå ignoreres den",
+            LOG.info("Mottatt VedtakHendelse {} for henvisning {} var tidligere relevant for å oppdatere behandling. Nå ignoreres den",
                 tbkData.getVidereBehandling(), henvisning);
+            // TODO TFP-5599 riktig å sette på vent?
+            if (åpenTilbakekreving != null) {
+                behandlingskontrollTjeneste.settBehandlingPåVentUtenSteg(åpenTilbakekreving, AksjonspunktDefinisjon.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG,
+                    LocalDateTime.now().plus(Frister.KRAVGRUNNLAG_FØRSTE), Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG);
+            }
         }
     }
+
 
     public Henvisning hentHenvisning(UUID behandling) {
         return fagsystemKlient.hentBehandlingOptional(behandling)
@@ -125,5 +141,21 @@ public class HendelseHåndtererTjeneste {
         taskData.setBehandlingType(BehandlingType.TILBAKEKREVING);
 
         taskTjeneste.lagre(taskData.getProsessTaskData());
+    }
+
+    private void rewindTilbakekrevingTilStart(Behandling åpenTilbakekreving, Henvisning henvisning, UUID eksternBehandlingUuid) {
+        EksternBehandling eksternBehandling = new EksternBehandling(åpenTilbakekreving, henvisning, eksternBehandlingUuid);
+        eksternBehandlingRepository.lagre(eksternBehandling);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(åpenTilbakekreving);
+        behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(åpenTilbakekreving, kontekst);
+        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.INOPPSTEG);
+        lagFortsettBehandlingTask(åpenTilbakekreving);
+    }
+
+    private void lagFortsettBehandlingTask(Behandling behandling) {
+        ProsessTaskData taskData = ProsessTaskData.forProsessTask(FortsettBehandlingTask.class);
+        taskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        taskData.setCallIdFraEksisterende();
+        taskTjeneste.lagre(taskData);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
                 <!-- oppdaterer versjon for å bli kvitt CVE-2023-34455 CVE-2023-34454 CVE-2023-34453 -->
-                <version>1.1.10.5</version>
+                <version>1.1.10.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Vi har regelmessig noen tilfelle av flere raske vedtak med aksjonspunkt i simulering (fx tvillinger med 2 PSB-saker).
TFP-5599 gjør følgende når det finnes en åpen TBK: 
* Valgt TBK uten varsel setter eksisterende på vent (på ny status eller kravgrunnlag). Men bare dersom faktisk sendt oppdrag.
* Valgt TBK med varsel - lagrer eksternbehandling (slik som opprett) og gjør rewind til start. 

Et alternativ til punkt 2 er å henlegge eksisterende TBK-behandling og opprette ny (tilsv Søknad merget og henlagt)