### PR TITLE
Reiterer utledning av differanse etter patching

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/beregn/migrer/MigrerBeregningsresultatTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/beregn/migrer/MigrerBeregningsresultatTask.java
@@ -169,6 +169,10 @@ public class MigrerBeregningsresultatTask implements ProsessTaskHandler {
                 p.setSkattBeløp(p.getSkattBeløp().add(sumSkatt));
                 p.setTilbakekrevingBeløpEtterSkatt(p.getSkattBeløp().subtract(sumSkatt));
                 endret = true;
+                var nyttReprodusert = tilbakekrevingsvedtakTjeneste.lagTilbakekrevingsvedtak(behandlingId, beregning);
+                LocalDateTimeline<BigDecimal> nyeReproduserteVerdier = hentVerdierFraReprodusertVedtak(nyttReprodusert, reproduserteVerdierFraBeløp);
+                differanse = gjeldendeVerdier.crossJoin(nyeReproduserteVerdier, subtract)
+                    .filterValue(b -> b.signum() != 0);
             }
         }
         if (endret) {

--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/iverksettevedtak/tjeneste/TilbakekrevingsvedtakTjeneste.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/iverksettevedtak/tjeneste/TilbakekrevingsvedtakTjeneste.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.kontrakter.fpwsproxy.tilbakekreving.iverksett.TilbakekrevingVedtakDTO;
+import no.nav.foreldrepenger.tilbakekreving.behandling.beregning.BeregningResultat;
 import no.nav.foreldrepenger.tilbakekreving.behandling.beregning.BeregningsresultatTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.vurdertforeldelse.VurdertForeldelseRepository;
 import no.nav.foreldrepenger.tilbakekreving.grunnlag.KravgrunnlagRepository;
@@ -39,6 +40,15 @@ public class TilbakekrevingsvedtakTjeneste {
         var kravgrunnlag = kravgrunnlagRepository.finnKravgrunnlag(behandlingId);
         var vurdertForeldelse = vurdertForeldelseRepository.finnVurdertForeldelse(behandlingId).orElse(null);
         var beregningResultat = beregningsresultatTjeneste.finnEllerBeregn(behandlingId);
+        var tilbakekrevingPerioder = vedtakPeriodeBeregner.lagTilbakekrevingsPerioder(kravgrunnlag, vurdertForeldelse,
+            beregningResultat);
+        validerSkattBeløp(tilbakekrevingPerioder);
+        return TilbakekrevingsvedtakMapper.tilDto(kravgrunnlag, tilbakekrevingPerioder);
+    }
+
+    public TilbakekrevingVedtakDTO lagTilbakekrevingsvedtak(Long behandlingId, BeregningResultat beregningResultat) {
+        var kravgrunnlag = kravgrunnlagRepository.finnKravgrunnlag(behandlingId);
+        var vurdertForeldelse = vurdertForeldelseRepository.finnVurdertForeldelse(behandlingId).orElse(null);
         var tilbakekrevingPerioder = vedtakPeriodeBeregner.lagTilbakekrevingsPerioder(kravgrunnlag, vurdertForeldelse,
             beregningResultat);
         validerSkattBeløp(tilbakekrevingPerioder);


### PR DESCRIPTION
Vil øke presisjon der perioder kan avvike mellom kravgrunnlag og beregningsresultat - samme diff legges ikke på flere BRperioder.