### PR TITLE
TFP-5671: Ikke lagre særlige grunner om beløpet er under 4R og skal ikke tilbakekreves

### DIFF
--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/vilkårsvurdering/AutomatiskVurdertVilkårTjeneste.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/vilkårsvurdering/AutomatiskVurdertVilkårTjeneste.java
@@ -39,10 +39,10 @@ public class AutomatiskVurdertVilkårTjeneste {
     public void automatiskVurdertVilkår(Behandling behandling, String begrunnelse) {
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         long behandlingId = behandling.getId();
-        List<DetaljertFeilutbetalingPeriodeDto> feilutbetaltePerioder = vilkårsvurderingTjeneste.hentDetaljertFeilutbetalingPerioder(behandlingId);
-        List<VilkårsvurderingPerioderDto> vilkårsvurdertePerioder = feilutbetaltePerioder.stream().filter(periode -> !periode.isForeldet())
+        var feilutbetaltePerioder = vilkårsvurderingTjeneste.hentDetaljertFeilutbetalingPerioder(behandlingId);
+        var vilkårsvurdertePerioder = feilutbetaltePerioder.stream().filter(periode -> !periode.isForeldet())
                 .map(periode -> lagVilkårsvurderingPeriode(periode.tilPeriode(), begrunnelse))
-                .collect(Collectors.toList());
+                .toList();
         vilkårsvurderingTjeneste.lagreVilkårsvurdering(behandlingId, vilkårsvurdertePerioder);
         //Aksjonpunkt oppretter ikke automatisk for automatisk saksbehandling. Det opprettes manuelt for å vise vilkår data i frontend.
         lagUtførtAksjonspunkt(kontekst, behandling);

--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/vilkårsvurdering/VilkårsvurderingTjeneste.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/vilkårsvurdering/VilkårsvurderingTjeneste.java
@@ -13,11 +13,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-
 import no.nav.foreldrepenger.tilbakekreving.behandling.dto.DetaljertFeilutbetalingPeriodeDto;
 import no.nav.foreldrepenger.tilbakekreving.behandling.dto.FeilutbetalingPerioderDto;
 import no.nav.foreldrepenger.tilbakekreving.behandling.dto.ForeldelsePeriodeMedBeløpDto;
@@ -50,6 +52,7 @@ import no.nav.foreldrepenger.tilbakekreving.grunnlag.kodeverk.KlasseType;
 @ApplicationScoped
 @Transactional
 public class VilkårsvurderingTjeneste {
+    private static final Logger LOG = LoggerFactory.getLogger(VilkårsvurderingTjeneste.class);
 
     private KravgrunnlagRepository grunnlagRepository;
     private FaktaFeilutbetalingRepository faktaFeilutbetalingRepository;
@@ -97,9 +100,10 @@ public class VilkårsvurderingTjeneste {
         for (VilkårsvurderingPerioderDto periode : vilkarsVurdertPerioder) {
             if (erPeriodeForeldet(behandlingId, periode.getFom(), periode.getTom())) {
                 //TODO kaste exception istedet, det skal ikke skje at saksbehandler vurderer en foreldet periode
+                LOG.warn("Bør ikke kunne skje at en saksbehandler vurderer en foreldet periode");
                 continue;
             }
-            VilkårVurderingPeriodeEntitet periodeEntitet = VilkårVurderingPeriodeEntitet.builder()
+            var periodeEntitet = VilkårVurderingPeriodeEntitet.builder()
                     .medPeriode(periode.getFom(), periode.getTom())
                     .medBegrunnelse(periode.getBegrunnelse())
                     .medVilkårResultat(periode.getVilkårResultat())
@@ -113,8 +117,8 @@ public class VilkårsvurderingTjeneste {
             vilkårVurderingEntitet.leggTilPeriode(periodeEntitet);
         }
 
-        Optional<VilkårVurderingEntitet> forrigeEntitet = vilkårsvurderingRepository.finnVilkårsvurdering(behandlingId);
-        VilkårVurderingEntitet forrigeVurdering = forrigeEntitet.orElse(null);
+        var forrigeEntitet = vilkårsvurderingRepository.finnVilkårsvurdering(behandlingId);
+        var forrigeVurdering = forrigeEntitet.orElse(null);
 
         vilkårsvurderingHistorikkInnslagTjeneste.lagHistorikkInnslag(behandlingId, forrigeVurdering, vilkårVurderingEntitet);
 


### PR DESCRIPTION
Om en SBH velger å tilbakekreve og velger Grunn Annet og så ombestemmer seg, så vil hele strukturen bli oversendt backend og så lagret som vilkår. 
Dette skaper trøbbel ved iverksetting, ved validering av brevtekster mot perioder.