### PR TITLE
Bump openHtmlToPdf bibliotek til en fork som faktisk vedlikeholdes.

### DIFF
--- a/integrasjontjenester/pdfgen/pom.xml
+++ b/integrasjontjenester/pdfgen/pom.xml
@@ -26,11 +26,11 @@
             <version>${verapdf-validation-model.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.openhtmltopdf</groupId>
+            <groupId>at.datenwort.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.openhtmltopdf</groupId>
+            <groupId>at.datenwort.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-pdfbox</artifactId>
             <exclusions>
                 <exclusion>
@@ -42,12 +42,12 @@
         </dependency>
         <dependency>
             <!-- Optional, leave out if you do not need logging via slf4j. -->
-            <groupId>com.openhtmltopdf</groupId>
+            <groupId>at.datenwort.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-slf4j</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.openhtmltopdf</groupId>
+            <groupId>at.datenwort.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-svg-support</artifactId>
             <exclusions>
                 <!-- denne drar inn to ulike versjoner av org.apache.xmlgraphics.xml-graphics-commons  -->

--- a/integrasjontjenester/pdfgen/src/main/java/no/nav/foreldrepenger/tilbakekreving/pdfgen/PdfGenerator.java
+++ b/integrasjontjenester/pdfgen/src/main/java/no/nav/foreldrepenger/tilbakekreving/pdfgen/PdfGenerator.java
@@ -7,11 +7,14 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+
 import com.openhtmltopdf.extend.FSSupplier;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+
 import com.openhtmltopdf.slf4j.Slf4jLogger;
 import com.openhtmltopdf.svgsupport.BatikSVGDrawer;
+
 import com.openhtmltopdf.util.XRLog;
 
 import no.nav.foreldrepenger.tilbakekreving.pdfgen.validering.PdfaValidator;

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <fp-tidsserie.version>2.7.1</fp-tidsserie.version>
 
-        <openhtmltopdf.version>1.0.10</openhtmltopdf.version>
+        <openhtmltopdf.version>1.1.4</openhtmltopdf.version>
         <handlebars.version>4.3.1</handlebars.version>
         <open.batik.version>1.17</open.batik.version>
 
@@ -358,24 +358,29 @@
             </dependency>
 
             <dependency>
-                <groupId>com.openhtmltopdf</groupId>
+                <groupId>at.datenwort.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-core</artifactId>
                 <version>${openhtmltopdf.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.openhtmltopdf</groupId>
+                <groupId>at.datenwort.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-pdfbox</artifactId>
                 <version>${openhtmltopdf.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.openhtmltopdf</groupId>
+                <groupId>at.datenwort.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-svg-support</artifactId>
                 <version>${openhtmltopdf.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.openhtmltopdf</groupId>
+                <groupId>at.datenwort.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-slf4j</artifactId>
                 <version>${openhtmltopdf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>pdfbox</artifactId>
+                <version>3.0.1</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>

--- a/web/src/test/resources/application-vtp-fptilbake.properties
+++ b/web/src/test/resources/application-vtp-fptilbake.properties
@@ -13,7 +13,7 @@ abac.attributt.drift=no.nav.abac.attributter.foreldrepenger.drift
 # Azure
 azure.app.client.id=vtp
 azure.app.client.secret=vtp
-azure.app.well.known.url=http://authserver:8086/azureAd/.well-known/openid-configuration
+azure.app.well.known.url=http://localhost:8060/rest/azuread/.well-known/openid-configuration
 
 # OIDC/STS
 oidc.sts.well.known.url=http://localhost:8060/rest/v1/sts/.well-known/openid-configuration


### PR DESCRIPTION
Har testet med autotest lokalt og ting ser egentlig greit ut. 

Det som er interessant er at man ikke får 
`PDType1Font: Using fallback font LiberationSans for base font Helvetica`
melding i loggen.

Så jeg tror at det henger sammen med at `gcr.io/distroless/java21-debian12:nonroot` imaget vi bruker med dokgen ikke har de fontene installert.