### PR TITLE
Fikser vedtaksbrev utsending

### DIFF
--- a/integrasjontjenester/pdfgen/src/main/java/no/nav/foreldrepenger/tilbakekreving/pdfgen/validering/PdfaValidator.java
+++ b/integrasjontjenester/pdfgen/src/main/java/no/nav/foreldrepenger/tilbakekreving/pdfgen/validering/PdfaValidator.java
@@ -41,7 +41,7 @@ public class PdfaValidator {
     }
 
     private static void validatePdf(InputStream inputStream) throws ModelParsingException, EncryptedPdfException, IOException, ValidationException {
-        PDFAFlavour flavour = PDFAFlavour.fromString("2u");
+        PDFAFlavour flavour = PDFAFlavour.fromString("2b");
         try (PDFAValidator validator = Foundries.defaultInstance().createValidator(flavour, false)) {
             try (PDFAParser parser = Foundries.defaultInstance().createParser(inputStream, flavour)) {
                 ValidationResult result = validator.validate(parser);


### PR DESCRIPTION
Ang bruk av ligaruter og denne [tråden](https://nav-it.slack.com/archives/CEKQHNLLU/p1710317475654249) så blir `ft` tegn transformert til `ɇ` i dokumentet. Dette fører til at 2u validering feiler. 

Vi gjør validering noe mindre restriktiv med 2B men likevel krav oppfyllende.

En mulig løsning er å bytte font. Vi har prøvd med Roboto og NotoSans med gode resultater. 