### PR TITLE
Consumer for å lagre nødvendigheter etter at behandling er lagret, før event

### DIFF
--- a/behandlingskontroll/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingskontroll/impl/BehandlingskontrollTjeneste.java
+++ b/behandlingskontroll/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingskontroll/impl/BehandlingskontrollTjeneste.java
@@ -380,10 +380,11 @@ public class BehandlingskontrollTjeneste {
     /**
      * Lagrer en ny behandling i behandlingRepository og fyrer av event om at en Behandling er opprettet
      */
-    public void opprettBehandling(BehandlingskontrollKontekst kontekst, Behandling behandling) {
+    public void opprettBehandling(BehandlingskontrollKontekst kontekst, Behandling behandling, Consumer<Behandling> etterLagring) {
         final var fagsakLås = serviceProvider.taFagsakLås(behandling.getFagsakId());
         behandlingRepository.lagre(behandling, kontekst.getSkriveLås());
         serviceProvider.oppdaterLåsVersjon(fagsakLås);
+        etterLagring.accept(behandling);
         eventPubliserer.fireEvent(kontekst, null, behandling.getStatus());
     }
 
@@ -394,10 +395,6 @@ public class BehandlingskontrollTjeneste {
         behandlingRepository.lagre(behandling, kontekst.getSkriveLås());
         eventPubliserer.fireEvent(kontekst, gammelStatus, behandling.getStatus());
 
-    }
-
-    public void publiserBehandlingStatusEtterOpprettet(BehandlingskontrollKontekst kontekst, Behandling behandling) {
-        eventPubliserer.fireEvent(kontekst, null, behandling.getStatus());
     }
 
     /**

--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingRevurderingTjeneste.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingRevurderingTjeneste.java
@@ -103,11 +103,8 @@ public class BehandlingRevurderingTjeneste {
             revurdering.setAnsvarligSaksbehandler(opprettetAv);
         }
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
-        behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);
-
-        opprettRelasjonMedEksternBehandling(henvisning, revurdering, eksternUuid);
-
-        behandlingskontrollTjeneste.publiserBehandlingStatusEtterOpprettet(kontekst, revurdering);
+        behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering,
+            beh -> eksternBehandlingRepository.lagre(new EksternBehandling(beh, henvisning, eksternUuid)));
 
         // revurdering skal starte med Fakta om feilutbetaling
         behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst, BehandlingStegType.FAKTA_FEILUTBETALING, List.of(AksjonspunktDefinisjon.AVKLART_FAKTA_FEILUTBETALING));
@@ -140,11 +137,6 @@ public class BehandlingRevurderingTjeneste {
     private boolean harÅpenBehandling(long origBehandlingId) {
         Behandling behandling = behandlingRepository.hentBehandling(origBehandlingId);
         return !behandling.erAvsluttet();
-    }
-
-    private void opprettRelasjonMedEksternBehandling(Henvisning henvisning, Behandling revurdering, UUID eksternUuid) {
-        EksternBehandling eksternBehandling = new EksternBehandling(revurdering, henvisning, eksternUuid);
-        eksternBehandlingRepository.lagre(eksternBehandling);
     }
 
     private void kopierVergeInformasjon(long origBehandlingId, long behandlingId) {

--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjeneste.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjeneste.java
@@ -212,7 +212,7 @@ public class BehandlingTjeneste {
         }
         LOG.info("Oppretter Tilbakekrevingbehandling for [saksnummer: {} ] for ekstern Uuid [ {} ]", saksnummer, eksternBehandlingsinfoDto.getUuid());
 
-        henvisning = hentHenvisningHvisIkkeFinnes(henvisning, eksternBehandlingsinfoDto);
+        var brukHenvisning = hentHenvisningHvisIkkeFinnes(henvisning, eksternBehandlingsinfoDto);
 
         Fagsak fagsak = fagsakTjeneste.opprettFagsak(saksnummer, aktørId, fagsakYtelseType, eksternBehandlingsinfoDto.getSpråkkodeEllerDefault());
 
@@ -221,12 +221,8 @@ public class BehandlingTjeneste {
         OrganisasjonsEnhet organisasjonsEnhet = hentEnhetFraEksternBehandling(eksternBehandlingsinfoDto);
         behandling.setBehandlendeOrganisasjonsEnhet(organisasjonsEnhet);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
-        behandlingskontrollTjeneste.opprettBehandling(kontekst, behandling);
-
-        EksternBehandling eksternBehandling = new EksternBehandling(behandling, henvisning, eksternUuid);
-        eksternBehandlingRepository.lagre(eksternBehandling);
-
-        behandlingskontrollTjeneste.publiserBehandlingStatusEtterOpprettet(kontekst, behandling);
+        behandlingskontrollTjeneste.opprettBehandling(kontekst, behandling,
+            beh -> eksternBehandlingRepository.lagre(new EksternBehandling(beh, brukHenvisning, eksternUuid)));
 
         historikkinnslagTjeneste.opprettHistorikkinnslagForOpprettetBehandling(behandling); // FIXME: sjekk om journalpostId skal hentes ///
 


### PR DESCRIPTION
En del logikk er avhengig av at eksternbehandling er lagret før det sendes statusEvent.
Denne sørger for at ting gjøres mer elegant enn en dobbelevent