### PR TITLE
Løsner litt på intern validering i TilbakekrevingResultatRestTjeneste

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/beregningsresultat/TilbakekrevingResultatRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/beregningsresultat/TilbakekrevingResultatRestTjeneste.java
@@ -157,11 +157,11 @@ public class TilbakekrevingResultatRestTjeneste {
         }
         var overlappendeVilkårsvurdering = overlappendeVurderinger.get(0);
         var vurderingsperiode = vurderingPeriodeFunksjon.apply(overlappendeVilkårsvurdering);
-        if (vurderingsperiode.equals(resultatperiode)) {
+        if (resultatperiode.erOmsluttetAv(vurderingsperiode)) {
             return overlappendeVilkårsvurdering;
         }
         throw new IllegalArgumentException(
-            "Forventet at vurderingsperioden " + vurderingsperiode + " skulle ha samme periode som resulatperioden " + resultatperiode);
+            "Forventet at vurderingsperioden " + vurderingsperiode + " omslutter resulatperioden " + resultatperiode);
     }
 
     private static BigDecimal finnAndelAvBeløp(VilkårVurderingPeriodeEntitet vurdering) {


### PR DESCRIPTION
vurderingsperioder og resultatperioder er ikke nødvendigvis like.

Det er enklest å finne for vurderingsperioder for foreldelse. Her har typisk hele behandlingen en vurderingsperiode. Dersom saksbehandler så splitter vurderingsperioder for vilkårsvurdering, blir det flere resultatperioder for vurderingsperioden for foreldelse. 