### PR TITLE
TFP-5554: erstatt kodeverdi med kodenavn for HendelseUnderType i HistorikkV2Adapter

### DIFF
--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/historikkv2/HistorikkV2Adapter.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/historikkv2/HistorikkV2Adapter.java
@@ -245,10 +245,10 @@ public class HistorikkV2Adapter {
             .filter(felt -> HistorikkEndretFeltType.HENDELSE_UNDER_ÅRSAK.getKode().equals(felt.getNavn()))
             .findFirst();
         var underÅrsakFraVerdi = underårsakFelt.isPresent() && underårsakFelt.get().getKlFraVerdi() != null
-            ? HendelseUnderType.fraKode(underårsakFelt.get().getFraVerdi())
+            ? HendelseUnderType.fraKode(underårsakFelt.get().getFraVerdi()).getNavn()
             : null;
         var underÅrsakTilVerdi = underårsakFelt.isPresent() && underårsakFelt.get().getKlTilVerdi() != null
-            ? HendelseUnderType.fraKode(underårsakFelt.get().getTilVerdi())
+            ? HendelseUnderType.fraKode(underårsakFelt.get().getTilVerdi()).getNavn()
             : null;
         var endret = endretFelt.stream().anyMatch(felt -> felt.getFraVerdi() != null);
 


### PR DESCRIPTION
erstatter kodeverdi i historikkinnslag med kodenavn.
Ny tekst blir: `Hendelse er satt til §14-4 Fakta om svangerskap (Ikke helsefarlig for ventende barn)`
![Screenshot 2025-01-09 at 10 08 28](https://github.com/user-attachments/assets/ab69325c-7cae-4b12-9bb9-3e9fb12aba20)
