### PR TITLE
Håndtere mulig 409 fra dokdist

### DIFF
--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/dokdist/DokdistKlient.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/dokdist/DokdistKlient.java
@@ -41,7 +41,7 @@ public class DokdistKlient {
      */
     public DistribuerJournalpostResponse distribuerJournalpost(DistribuerJournalpostRequest request) {
         var rrequest = RestRequest.newPOSTJson(request, restConfig.endpoint(), restConfig);
-        return restClient.send(rrequest, DistribuerJournalpostResponse.class);
+        return restClient.sendExpectConflict(rrequest, DistribuerJournalpostResponse.class);
     }
 
     public void distribuerJournalpost(JournalpostId journalpostId, BrevMottaker mottaker, Distribusjonstype distribusjonstype) {


### PR DESCRIPTION
Merger og deployer når dokumentløsninger har patchet tilfelle som ikke har blitt distribuert - ellers vil task bare gå til ferdig uten at dokument blir distribuert.