### PR TITLE
Forvaltningsendepunkt for å hente vedtak 

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
@@ -455,13 +455,13 @@ public class ForvaltningBehandlingRestTjeneste {
     @Path("/hent-vedtak")
     @Operation(
         tags = "FORVALTNING-behandling",
-        description = "Tjeneste for å tvinge en behandling til å bli henlagt, selvom normale regler for saksbehandling ikke tillater henleggelse",
+        description = "Tjeneste for å hente tilbakekrevingsvedtak som sendes til oppdragsystemet. Kan kun brukes på behandling som er under iverksettelse",
         responses = {
             @ApiResponse(responseCode = "200", description = "Returnerer vedtak"),
             @ApiResponse(responseCode = "400", description = "Behandlingen har feil status"),
             @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil.")
         })
-    @BeskyttetRessurs(actionType = ActionType.CREATE, property = AbacProperty.DRIFT)
+    @BeskyttetRessurs(actionType = ActionType.READ, property = AbacProperty.FAGSAK)
     public Response hentTilbakekrevingVedtak(
         @TilpassetAbacAttributt(supplierClass = BehandlingReferanseAbacAttributter.AbacDataBehandlingReferanse.class)
         @QueryParam("behandlingId") @NotNull @Valid BehandlingReferanse behandlingReferanse) {

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
@@ -102,7 +102,7 @@ class ForvaltningBehandlingRestTjenesteTest {
         behandlingskontrollTjeneste = new BehandlingskontrollTjeneste(new BehandlingskontrollServiceProvider(entityManager, behandlingModellRepository, eventPubliserer));
 
         forvaltningBehandlingRestTjeneste = new ForvaltningBehandlingRestTjeneste(repositoryProvider, taskTjeneste, behandlingresultatRepository,
-            mottattXmlRepository, kravgrunnlagMapper, kravgrunnlagTjeneste, eksternBehandlingRepository, null);
+            mottattXmlRepository, kravgrunnlagMapper, kravgrunnlagTjeneste, eksternBehandlingRepository, null, null);
         behandling = scenario.lagre(repositoryProvider);
     }
 


### PR DESCRIPTION
Bakgrunn

Vi har en behandling som står fast i iverksettingsteget med følgende feilmelding fra  oppdragsystemet:  'Innkrevd beløp = 0 ved delvis/full tilbakekreving'. Innkrevd beløp skal være høyere enn 0 her. Lager dette endepunktet for å se hva vi sender over til oppdragssystemet for å finne ut hvor feilen ligger.