### PR TITLE
TFP-5952 logge tilgangsdiff flytte ut abac-kode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <sonar.projectKey>navikt_fptilbake</sonar.projectKey>
 
         <!-- Jakarta deps -->
-        <felles.version>7.4.4</felles.version>
+        <felles.version>7.4.7</felles.version>
         <prosesstask.version>5.1.1</prosesstask.version>
         <fpkontrakter.version>9.2.1</fpkontrakter.version>
         <abakus-kontrakt.version>2.2.1</abakus-kontrakt.version>

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/AppPepImpl.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/AppPepImpl.java
@@ -1,0 +1,72 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac;
+
+import static no.nav.vedtak.sikkerhet.abac.AbacResultat.AVSLÅTT_ANNEN_ÅRSAK;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Inject;
+import jakarta.interceptor.Interceptor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.tilbakekreving.fagsystem.ApplicationName;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.AppPdpKlientImpl;
+import no.nav.vedtak.sikkerhet.abac.PdpRequestBuilder;
+import no.nav.vedtak.sikkerhet.abac.PepImpl;
+import no.nav.vedtak.sikkerhet.abac.Tilgangsbeslutning;
+import no.nav.vedtak.sikkerhet.abac.internal.BeskyttetRessursAttributter;
+import no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
+import no.nav.vedtak.sikkerhet.pdp.PdpKlientImpl;
+import no.nav.vedtak.sikkerhet.tilgang.AnsattGruppeKlient;
+import no.nav.vedtak.sikkerhet.tilgang.PopulasjonKlient;
+
+@Default
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION + 1)
+public class AppPepImpl extends PepImpl {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PepImpl.class);
+    private static final String PIP = ForeldrepengerAttributter.RESOURCE_TYPE_INTERNAL_PIP;
+
+    private final PdpRequestBuilder pdpRequestBuilder;
+    private final AppPdpKlientImpl lokalPdpKlient;
+
+
+    @Inject
+    public AppPepImpl(PdpKlientImpl pdpKlient,
+                      PopulasjonKlient populasjonKlient,
+                      AnsattGruppeKlient ansattGruppeKlient,
+                      PdpRequestBuilder pdpRequestBuilder,
+                      AppPdpKlientImpl appPdpKlient) {
+        super(pdpKlient, populasjonKlient, ansattGruppeKlient, pdpRequestBuilder);
+        this.pdpRequestBuilder = pdpRequestBuilder;
+        this.lokalPdpKlient = appPdpKlient;
+    }
+
+    @Override
+    public Tilgangsbeslutning vurderTilgang(BeskyttetRessursAttributter beskyttetRessursAttributter) {
+        var applikasjon = ApplicationName.hvilkenTilbake();
+        switch (applikasjon) {
+            case FPTILBAKE -> {
+                return super.vurderTilgang(beskyttetRessursAttributter);
+            }
+            case K9TILBAKE -> {
+                var appRessurser = pdpRequestBuilder.lagAppRessursData(beskyttetRessursAttributter.getDataAttributter());
+
+                if (IdentType.Systemressurs.equals(beskyttetRessursAttributter.getIdentType())) {
+                    return super.vurderLokalTilgang(beskyttetRessursAttributter, appRessurser);
+                } else if (PIP.equals(beskyttetRessursAttributter.getResourceType())) { // pip tilgang bør vurderes kun lokalt
+                    return new Tilgangsbeslutning(AVSLÅTT_ANNEN_ÅRSAK, beskyttetRessursAttributter, appRessurser);
+                } else {
+                    return lokalPdpKlient.forespørTilgang(beskyttetRessursAttributter, "k9", appRessurser);
+                }
+            }
+            default -> throw new IllegalStateException("applikasjonsnavn er satt til " + applikasjon + " som ikke er en støttet verdi");
+        }
+
+    }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/AppPdpConsumerImpl.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/AppPdpConsumerImpl.java
@@ -1,0 +1,101 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.XacmlRequest;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.XacmlResponse;
+import no.nav.vedtak.exception.IntegrasjonException;
+import no.nav.vedtak.exception.ManglerTilgangException;
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
+import no.nav.vedtak.sikkerhet.kontekst.Systembruker;
+
+@ApplicationScoped
+public class AppPdpConsumerImpl {
+
+    private static final String MEDIA_TYPE = "application/xacml+json";
+    private static final Logger LOG = LoggerFactory.getLogger(AppPdpConsumerImpl.class);
+
+    private HttpClient client;
+    private ObjectReader reader;
+
+    private URI pdpUrl;
+    private String basicCredentials;
+
+    AppPdpConsumerImpl() {
+    } // CDI
+
+    @Inject
+    public AppPdpConsumerImpl(@KonfigVerdi(value = "abac.pdp.endpoint.url", defaultVerdi = "http://abac-foreldrepenger.teamabac/application/authorize") String pdpUrl) {
+        this.pdpUrl = URI.create(pdpUrl);
+        this.basicCredentials = basicCredentials(Systembruker.username(), Systembruker.password());
+        // TODO - vurder om bør settes static final?
+        this.client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).proxy(HttpClient.Builder.NO_PROXY).build();
+        this.reader = DefaultJsonMapper.getObjectMapper().readerFor(XacmlResponse.class);
+    }
+
+    public XacmlResponse evaluate(XacmlRequest xacmlRequest) {
+        var request = HttpRequest.newBuilder()
+            .header("Authorization", basicCredentials)
+            .header("Content-type", MEDIA_TYPE)
+            .timeout(Duration.ofSeconds(5))
+            .uri(pdpUrl)
+            .POST(HttpRequest.BodyPublishers.ofString(DefaultJsonMapper.toJson(xacmlRequest), UTF_8))
+            .build();
+
+        // Enkel retry
+        int i = 2;
+        while (i-- > 0) {
+            try {
+                return send(request);
+            } catch (IntegrasjonException e) {
+                LOG.trace("F-157387 IntegrasjonException ved kall {} til PDP", 2 - i, e);
+            }
+        }
+        return send(request);
+    }
+
+    private XacmlResponse send(HttpRequest request) {
+        try {
+            var response = client.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
+            if (response != null && response.statusCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                throw new ManglerTilgangException("F-157388", "Ingen tilgang fra PDP");
+            }
+            if (response == null || response.body() == null) {
+                LOG.info("ingen response fra PDP status = {}", response == null ? "null" : response.statusCode());
+                throw new IntegrasjonException("F-157386", "Kunne ikke hente svar fra PDP");
+            }
+            return reader.readValue(response.body(), XacmlResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new IntegrasjonException("F-208314", "Kunne ikke deserialisere objekt til JSON", e);
+        } catch (IOException e) {
+            throw new IntegrasjonException("F-091324", "Uventet IO-exception mot PDP", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IntegrasjonException("F-432938", "InterruptedException ved kall mot PDP", e);
+        }
+    }
+
+    private static String basicCredentials(String username, String password) {
+        return "Basic " + Base64.getEncoder().encodeToString(String.format("%s:%s", username, password).getBytes(UTF_8));
+    }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/AppPdpKlientImpl.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/AppPdpKlientImpl.java
@@ -1,0 +1,90 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp;
+
+import java.util.List;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.Advice;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.Decision;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.XacmlResponse;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.XacmlResponseMapper;
+import no.nav.vedtak.exception.TekniskException;
+import no.nav.vedtak.log.util.LoggerUtils;
+import no.nav.vedtak.sikkerhet.abac.AbacResultat;
+import no.nav.vedtak.sikkerhet.abac.Tilgangsbeslutning;
+import no.nav.vedtak.sikkerhet.abac.internal.BeskyttetRessursAttributter;
+import no.nav.vedtak.sikkerhet.abac.pdp.AppRessursData;
+
+@Dependent
+public class AppPdpKlientImpl {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AppPdpKlientImpl.class);
+
+    private final AppPdpConsumerImpl pdp;
+
+    @Inject
+    public AppPdpKlientImpl(AppPdpConsumerImpl pdp) {
+        this.pdp = pdp;
+    }
+
+    public Tilgangsbeslutning forespørTilgang(BeskyttetRessursAttributter beskyttetRessursAttributter, String domene, AppRessursData appRessursData) {
+        var request = XacmlRequestMapper.lagXacmlRequest(beskyttetRessursAttributter, domene, appRessursData);
+        var response = pdp.evaluate(request);
+        var hovedresultat = resultatFraResponse(response);
+        return new Tilgangsbeslutning(hovedresultat, beskyttetRessursAttributter, appRessursData);
+    }
+
+    private static AbacResultat resultatFraResponse(XacmlResponse response) {
+        var decisions = XacmlResponseMapper.getDecisions(response);
+
+        for (var decision : decisions) {
+            if (decision == Decision.Indeterminate) {
+                throw new TekniskException("F-080281",
+                    String.format("Decision %s fra PDP, dette skal aldri skje. Full JSON response: %s", decision, response));
+            }
+        }
+
+        var biasedDecision = createAggregatedDecision(decisions);
+        handlObligation(response);
+
+        if (biasedDecision == Decision.Permit) {
+            return AbacResultat.GODKJENT;
+        }
+
+        var denyAdvice = XacmlResponseMapper.getAdvice(response);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Deny fra PDP, advice var: {}", LoggerUtils.toStringWithoutLineBreaks(denyAdvice));
+        }
+        if (denyAdvice.contains(Advice.DENY_KODE_6)) {
+            return AbacResultat.AVSLÅTT_KODE_6;
+        }
+        if (denyAdvice.contains(Advice.DENY_KODE_7)) {
+            return AbacResultat.AVSLÅTT_KODE_7;
+        }
+        if (denyAdvice.contains(Advice.DENY_EGEN_ANSATT)) {
+            return AbacResultat.AVSLÅTT_EGEN_ANSATT;
+        }
+        return AbacResultat.AVSLÅTT_ANNEN_ÅRSAK;
+    }
+
+    private static Decision createAggregatedDecision(List<Decision> decisions) {
+        for (var decision : decisions) {
+            if (decision != Decision.Permit) {
+                return Decision.Deny;
+            }
+        }
+        return Decision.Permit;
+    }
+
+    private static void handlObligation(XacmlResponse response) {
+        var obligations = XacmlResponseMapper.getObligations(response);
+        if (!obligations.isEmpty()) {
+            throw new TekniskException("F-576027", String.format("Mottok ukjente obligations fra PDP: %s", obligations));
+        }
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/XacmlRequestMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/XacmlRequestMapper.java
@@ -1,0 +1,106 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.Category;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.NavFellesAttributter;
+import no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml.XacmlRequest;
+import no.nav.vedtak.sikkerhet.abac.internal.BeskyttetRessursAttributter;
+import no.nav.vedtak.sikkerhet.abac.pdp.AppRessursData;
+
+
+public class XacmlRequestMapper {
+
+    private static final Environment ENV = Environment.current();
+
+    public static XacmlRequest lagXacmlRequest(BeskyttetRessursAttributter beskyttetRessursAttributter,
+                                               String domene,
+                                               AppRessursData appRessursData) {
+        var actionAttributes = new XacmlRequest.Attributes(List.of(actionInfo(beskyttetRessursAttributter)));
+
+        List<XacmlRequest.AttributeAssignment> envList = new ArrayList<>();
+        envList.add(getPepIdInfo(beskyttetRessursAttributter));
+        envList.addAll(getTokenEnvironmentAttrs(beskyttetRessursAttributter));
+
+        var envAttributes = new XacmlRequest.Attributes(envList);
+
+        List<XacmlRequest.Attributes> resourceAttributes = new ArrayList<>();
+        var identer = hentIdenter(appRessursData);
+        if (identer.isEmpty()) {
+            resourceAttributes.add(resourceInfo(beskyttetRessursAttributter, domene, appRessursData, null));
+        } else {
+            identer.forEach(ident -> resourceAttributes.add(resourceInfo(beskyttetRessursAttributter, domene, appRessursData, ident)));
+        }
+
+        Map<Category, List<XacmlRequest.Attributes>> requestMap = new HashMap<>();
+        requestMap.put(Category.Action, List.of(actionAttributes));
+        requestMap.put(Category.Environment, List.of(envAttributes));
+        requestMap.put(Category.Resource, resourceAttributes);
+        return new XacmlRequest(requestMap);
+    }
+
+    private static XacmlRequest.Attributes resourceInfo(BeskyttetRessursAttributter beskyttetRessursAttributter,
+                                                        String domene,
+                                                        AppRessursData appRessursData,
+                                                        Ident ident) {
+        List<XacmlRequest.AttributeAssignment> attributes = new ArrayList<>();
+
+        attributes.add(new XacmlRequest.AttributeAssignment(NavFellesAttributter.RESOURCE_FELLES_DOMENE, domene));
+        attributes.add(
+            new XacmlRequest.AttributeAssignment(NavFellesAttributter.RESOURCE_FELLES_RESOURCE_TYPE, beskyttetRessursAttributter.getResourceType()));
+
+        appRessursData.getResources()
+            .values()
+            .stream()
+            .map(ressursData -> new XacmlRequest.AttributeAssignment(ressursData.nøkkel().getKey(), ressursData.verdi()))
+            .forEach(attributes::add);
+
+        if (ident != null) {
+            attributes.add(new XacmlRequest.AttributeAssignment(ident.key(), ident.ident()));
+        }
+        return new XacmlRequest.Attributes(attributes);
+    }
+
+    private static XacmlRequest.AttributeAssignment actionInfo(final BeskyttetRessursAttributter beskyttetRessursAttributter) {
+        return new XacmlRequest.AttributeAssignment(NavFellesAttributter.XACML10_ACTION_ID,
+            beskyttetRessursAttributter.getActionType().getEksternKode());
+    }
+
+    private static XacmlRequest.AttributeAssignment getPepIdInfo(final BeskyttetRessursAttributter beskyttetRessursAttributter) {
+        return new XacmlRequest.AttributeAssignment(NavFellesAttributter.ENVIRONMENT_FELLES_PEP_ID,
+            Optional.ofNullable(beskyttetRessursAttributter.getPepId()).orElse(getPepId()));
+    }
+
+    private static List<XacmlRequest.AttributeAssignment> getTokenEnvironmentAttrs(final BeskyttetRessursAttributter beskyttetRessursAttributter) {
+        String envTokenBodyAttributt = switch (beskyttetRessursAttributter.getToken().getTokenType()) {
+            case OIDC -> NavFellesAttributter.ENVIRONMENT_FELLES_OIDC_TOKEN_BODY;
+            case TOKENX -> NavFellesAttributter.ENVIRONMENT_FELLES_TOKENX_TOKEN_BODY;
+        };
+        var assignement = new XacmlRequest.AttributeAssignment(envTokenBodyAttributt, beskyttetRessursAttributter.getToken().getTokenBody());
+        return List.of(assignement);
+    }
+
+    private static String getPepId() {
+        return ENV.getNaisAppName();
+    }
+
+    private static List<Ident> hentIdenter(AppRessursData appRessursData) {
+        List<Ident> identer = new ArrayList<>();
+        appRessursData.getAktørIdSet()
+            .stream()
+            .map(it -> new Ident(NavFellesAttributter.RESOURCE_FELLES_PERSON_AKTOERID_RESOURCE, it))
+            .forEach(identer::add);
+
+        appRessursData.getFødselsnumre().stream().map(it -> new Ident(NavFellesAttributter.RESOURCE_FELLES_PERSON_FNR, it)).forEach(identer::add);
+
+        return identer;
+    }
+
+    public record Ident(String key, String ident) {
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/Advice.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/Advice.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml;
+
+public enum Advice {
+    DENY_KODE_6,
+    DENY_KODE_7,
+    DENY_EGEN_ANSATT;
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/Category.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/Category.java
@@ -1,0 +1,12 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml;
+
+public enum Category {
+    Resource,
+    Action,
+    Environment,
+    AccessSubject,
+    RecipientSubject,
+    IntermediarySubject,
+    Codebase,
+    RequestingMachine;
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/Decision.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/Decision.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml;
+
+public enum Decision {
+    Permit,
+    Deny,
+    NotApplicable,
+    Indeterminate;
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/NavFellesAttributter.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/NavFellesAttributter.java
@@ -1,0 +1,23 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml;
+
+/**
+ * Inneholder subset av konstanter deklareret i aba-common-attributter modul i
+ * Nav.
+ *
+ * @see abac-common-attributes-alfa / CommonAttributter.
+ */
+public class NavFellesAttributter {
+
+    public static final String XACML10_ACTION_ID = "urn:oasis:names:tc:xacml:1.0:action:action-id";
+
+    public static final String ENVIRONMENT_FELLES_TOKENX_TOKEN_BODY = "no.nav.abac.attributter.environment.felles.tokenx_token_body";
+    public static final String ENVIRONMENT_FELLES_OIDC_TOKEN_BODY = "no.nav.abac.attributter.environment.felles.oidc_token_body";
+
+    public static final String ENVIRONMENT_FELLES_PEP_ID = "no.nav.abac.attributter.environment.felles.pep_id";
+
+    public static final String RESOURCE_FELLES_RESOURCE_TYPE = "no.nav.abac.attributter.resource.felles.resource_type";
+    public static final String RESOURCE_FELLES_DOMENE = "no.nav.abac.attributter.resource.felles.domene";
+    public static final String RESOURCE_FELLES_PERSON_FNR = "no.nav.abac.attributter.resource.felles.person.fnr";
+    public static final String RESOURCE_FELLES_PERSON_AKTOERID_RESOURCE = "no.nav.abac.attributter.resource.felles.person.aktoerId_resource";
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/XacmlRequest.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/XacmlRequest.java
@@ -1,0 +1,18 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record XacmlRequest(
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("Request") Map<Category, List<Attributes>> request) {
+
+    public static record Attributes(
+        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("Attribute") List<AttributeAssignment> attribute) {
+    }
+
+    public static record AttributeAssignment(@JsonProperty("AttributeId") String attributeId, @JsonProperty("Value") Object value) {
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/XacmlResponse.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/XacmlResponse.java
@@ -1,0 +1,22 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record XacmlResponse(@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("Response") List<Result> response) {
+
+    public static record Result(@JsonProperty("Decision") Decision decision,
+                                @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("Obligations") List<ObligationOrAdvice> obligations,
+                                @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("AssociatedAdvice") List<ObligationOrAdvice> associatedAdvice) {
+    }
+
+    public static record ObligationOrAdvice(@JsonProperty("Id") String id,
+                                            @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("AttributeAssignment") List<AttributeAssignment> attributeAssignment) {
+    }
+
+    public static record AttributeAssignment(@JsonProperty("AttributeId") String attributeId, @JsonProperty("Value") Object value) {
+    }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/XacmlResponseMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/server/jetty/abac/k9pdp/xacml/XacmlResponseMapper.java
@@ -1,0 +1,68 @@
+package no.nav.foreldrepenger.tilbakekreving.web.server.jetty.abac.k9pdp.xacml;
+
+
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public final class XacmlResponseMapper {
+
+    private XacmlResponseMapper() {
+    }
+
+    private static final String POLICY_IDENTIFIER = "no.nav.abac.attributter.adviceorobligation.deny_policy";
+    private static final String DENY_ADVICE_IDENTIFIER = "no.nav.abac.advices.reason.deny_reason";
+
+    public static List<XacmlResponse.ObligationOrAdvice> getObligations(XacmlResponse response) {
+        return Optional.ofNullable(response)
+            .map(XacmlResponse::response)
+            .orElse(List.of())
+            .stream()
+            .map(r -> Optional.ofNullable(r.obligations()).orElse(List.of()))
+            .flatMap(Collection::stream)
+            .toList();
+    }
+
+    public static List<Advice> getAdvice(XacmlResponse response) {
+        return Optional.ofNullable(response)
+            .map(XacmlResponse::response)
+            .orElse(List.of())
+            .stream()
+            .map(r -> Optional.ofNullable(r.associatedAdvice()).orElse(List.of()))
+            .flatMap(Collection::stream)
+            .map(XacmlResponseMapper::getAdviceFrom)
+            .flatMap(Collection::stream)
+            .toList();
+    }
+
+    private static List<Advice> getAdviceFrom(XacmlResponse.ObligationOrAdvice advice) {
+        if (!DENY_ADVICE_IDENTIFIER.equals(advice.id())) {
+            return List.of();
+        }
+        return advice.attributeAssignment().stream().map(XacmlResponseMapper::getAdvicefromObject).flatMap(Optional::stream).toList();
+    }
+
+    private static Optional<Advice> getAdvicefromObject(XacmlResponse.AttributeAssignment attribute) {
+        var attributeId = attribute.attributeId();
+
+        if (!POLICY_IDENTIFIER.equals(attributeId)) {
+            return Optional.empty();
+        }
+        var attributeValue = (String) attribute.value();
+        return switch (attributeValue) {
+            case "fp3_behandle_egen_ansatt" -> Optional.of(Advice.DENY_EGEN_ANSATT);
+            case "fp2_behandle_kode7" -> Optional.of(Advice.DENY_KODE_7);
+            case "fp1_behandle_kode6" -> Optional.of(Advice.DENY_KODE_6);
+            case "skjermede_navansatte_og_familiemedlemmer" -> Optional.of(Advice.DENY_EGEN_ANSATT);
+            case "adressebeskyttelse_fortrolig_adresse" -> Optional.of(Advice.DENY_KODE_7);
+            case "adressebeskyttelse_strengt_fortrolig_adresse" -> Optional.of(Advice.DENY_KODE_6);
+            case "adressebeskyttelse_strengt_fortrolig_adresse_utland" -> Optional.of(Advice.DENY_KODE_6);
+            default -> Optional.empty();
+        };
+    }
+
+    public static List<Decision> getDecisions(XacmlResponse response) {
+        return response.response().stream().map(XacmlResponse.Result::decision).toList();
+    }
+}


### PR DESCRIPTION
Slår på logging av avvik mellom abac og ny tilgang for fptilbake
Lar k9tilbake kalle klassisk abac. Flytter ut kode fra fp-felles - fase 1. 
Abac/Xacml vil senere utvides med mapping av enums til attributtnavn + at PdpRequestBuilder skilles ut (ny appressursdata)