### PR TITLE
Utleder KodeRestulat fra tilbakekrevingsbeløp isdf periode-nivå

### DIFF
--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/iverksettevedtak/tjeneste/TilbakekrevingVedtakPeriodeBeregner.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/iverksettevedtak/tjeneste/TilbakekrevingVedtakPeriodeBeregner.java
@@ -284,19 +284,19 @@ public class TilbakekrevingVedtakPeriodeBeregner {
     }
 
     private static void leggPåKodeResultat(VurdertForeldelse vurdertForeldelse, BeregningResultatPeriode bgPeriode, List<TilbakekrevingPeriode> tmp) {
-        tmp.stream().flatMap(p -> p.getBeløp().stream()).forEach(b -> b.medKodeResultat(utledKodeResultat(vurdertForeldelse, bgPeriode)));
+        tmp.stream().flatMap(p -> p.getBeløp().stream()).forEach(b -> b.medKodeResultat(utledKodeResultat(vurdertForeldelse, bgPeriode, b)));
     }
 
-    private static KodeResultat utledKodeResultat(VurdertForeldelse vurdertForeldelse, BeregningResultatPeriode bgPeriode) {
+    private static KodeResultat utledKodeResultat(VurdertForeldelse vurdertForeldelse, BeregningResultatPeriode bgPeriode, TilbakekrevingBeløp andel) {
         if (vurdertForeldelse != null && vurdertForeldelse.getVurdertForeldelsePerioder()
             .stream()
             .anyMatch(vfp -> vfp.erForeldet() && vfp.getPeriode().overlapper(bgPeriode.getPeriode()))) {
             return KodeResultat.FORELDET;
         }
-        if (bgPeriode.getTilbakekrevingBeløpUtenRenter().signum() == 0) {
+        if (andel.getTilbakekrevBeløp().signum() == 0) {
             return KodeResultat.INGEN_TILBAKEKREVING;
         }
-        if (bgPeriode.getFeilutbetaltBeløp().compareTo(bgPeriode.getTilbakekrevingBeløpUtenRenter()) == 0) {
+        if (andel.getUinnkrevdBeløp().signum() == 0) {
             return KodeResultat.FULL_TILBAKEKREVING;
         }
         return KodeResultat.DELVIS_TILBAKEKREVING;

--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/iverksettevedtak.tjeneste/TilbakekrevingVedtakPeriodeBeregnerTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/iverksettevedtak.tjeneste/TilbakekrevingVedtakPeriodeBeregnerTest.java
@@ -15,6 +15,8 @@ import java.util.function.Function;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
+import no.nav.foreldrepenger.tilbakekreving.grunnlag.KodeResultat;
+
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
@@ -675,6 +677,48 @@ class TilbakekrevingVedtakPeriodeBeregnerTest {
             tilbakekrevingPeriode("2022-07-01,2022-07-31", 51555, 0, 51555, 0  , 16087),
             tilbakekrevingPeriode("2022-08-01,2022-08-02", 4910, 0, 4910,  0,1495),
             tilbakekrevingPeriode("2022-09-07,2022-09-30", 44190, 0, 44190, 0  , 15113));
+    }
+
+    @Test
+    void skal_utlede_resultatkode_separat_for_feriepenger_og_ytelse() {
+        Behandling behandling = simple.lagre(behandlingRepositoryProvider);
+        Long behandlingId = behandling.getId();
+
+        Periode periode1 = Periode.of(LocalDate.of(2025, 5, 2), LocalDate.of(2025, 5, 4));
+        Periode periode2 = Periode.of(LocalDate.of(2025, 5, 23), LocalDate.of(2025, 5, 30));
+        Kravgrunnlag431 kravgrunnlag = KravgrunnlagTestBuilder.medRepo(kravgrunnlagRepository).lagreKravgrunnlag(behandlingId, Map.of(
+            periode1, List.of (
+                KgBeløp.feil(1),
+                KgBeløp.ytelse(KlasseKode.PNBSATORD).medUtbetBeløp(1).medTilbakekrevBeløp(1).medSkattProsent(25)
+            ),
+            periode2, List.of(
+                KgBeløp.feil(2),
+                KgBeløp.ytelse(KlasseKode.PNBSATORD).medUtbetBeløp(1).medTilbakekrevBeløp(1).medSkattProsent(25),
+                KgBeløp.ytelse(KlasseKode.SPATFER).medUtbetBeløp(1).medTilbakekrevBeløp(1).medSkattProsent(0))
+        ), false);
+
+        VilkårsvurderingTestBuilder.medRepo(vilkårsvurderingRepository).lagre(behandlingId, Map.of(
+            periode1, VilkårsvurderingTestBuilder.VVurdering.grovtUaktsom(50),
+            periode2, VilkårsvurderingTestBuilder.VVurdering.grovtUaktsom(50)
+        ));
+
+        flushAndClear();
+
+        List<TilbakekrevingPeriode> resultat = beregner.lagTilbakekrevingsPerioder(behandlingId, kravgrunnlag);
+        assertThat(resultat).containsOnly(
+            TilbakekrevingPeriode.med(periode1).medRenter(0)
+                .medBeløp(TbkBeløp.feil(1))
+                .medBeløp(TbkBeløp.ytelse(KlasseKode.PNBSATORD).medNyttBeløp(0).medUtbetBeløp(1).medTilbakekrevBeløp(1).medUinnkrevdBeløp(0).medSkattBeløp(0)),
+            TilbakekrevingPeriode.med(periode2).medRenter(0)
+                .medBeløp(TbkBeløp.feil(2))
+                //er ikke så viktig hvilken av de to klassekodene som blir runda opp/ned, det er summen som er viktigst
+                .medBeløp(TbkBeløp.ytelse(KlasseKode.PNBSATORD).medNyttBeløp(0).medUtbetBeløp(1).medTilbakekrevBeløp(0).medUinnkrevdBeløp(1).medSkattBeløp(0))
+                .medBeløp(TbkBeløp.ytelse(KlasseKode.SPATFER).medNyttBeløp(0).medUtbetBeløp(1).medTilbakekrevBeløp(1).medUinnkrevdBeløp(0).medSkattBeløp(0))
+        );
+        //separat sjekk for klassekode siden den ikke er i equals-metoden på TilbakekrevingBeløp
+        TilbakekrevingPeriode resultatPeriode2 = resultat.stream().filter(p -> p.getPeriode().equals(periode2)).findFirst().get();
+        assertThat(resultatPeriode2.getBeløp().stream().filter(b->b.getKlassekode().equals(KlasseKode.PNBSATORD.getKode())).findFirst().get().getKodeResultat()).isEqualTo(KodeResultat.INGEN_TILBAKEKREVING);
+        assertThat(resultatPeriode2.getBeløp().stream().filter(b->b.getKlassekode().equals(KlasseKode.SPATFER.getKode())).findFirst().get().getKodeResultat()).isEqualTo(KodeResultat.FULL_TILBAKEKREVING);
     }
 
     private static BigDecimal finSumAv(Collection<TilbakekrevingPeriode> perioder, Function<TilbakekrevingBeløp, BigDecimal> hva, KlasseType klasseType) {


### PR DESCRIPTION
Dette skal fikse et tilfelle hvor iverksettingen feiler i validering i oppdragssystemet: saken har både tilbakekreving av ytelse og feriepenger i samme periode. Det er delvis tilbakekreving, og kun 1 kr feil på feriepengene, og i tilfellet rundes da ned til 0. Når vi sender DELVIS_TILBAKEKREVING (siden vi ser på periode-nivået) feiler valideringen siden 0 ikke passer med DELVIS_TILBAKEKREVING