### PR TITLE
historikk: Tydleggjere skille mellom aksjonspunktdefinisjon og beslutning

### DIFF
--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/historikkv2/HistorikkV2Adapter.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/historikkv2/HistorikkV2Adapter.java
@@ -344,10 +344,10 @@ public class HistorikkV2Adapter {
     private static List<String> fraAksjonspunktFelt(HistorikkinnslagTotrinnsvurdering aksjonspunktFelt) {
         var aksjonspunktTekst = aksjonspunktFelt.getAksjonspunktDefinisjon().getNavn();
         if (aksjonspunktFelt.erGodkjent()) {
-            return List.of(String.format("__%s er godkjent__", aksjonspunktTekst));
+            return List.of(String.format("__%s: Godkjent__", aksjonspunktTekst));
         } else {
             return List.of(
-                String.format("__%s må vurderes på nytt__", aksjonspunktTekst),
+                String.format("__%s: Må vurderes på nytt__", aksjonspunktTekst),
                 String.format("Kommentar: %s", aksjonspunktFelt.getBegrunnelse())
             );
         }


### PR DESCRIPTION
For "sak retur" historikkinnslag.

Før denne endring:
<img width="645" alt="Skjermbilde 2025-02-13 kl  14 47 49" src="https://github.com/user-attachments/assets/af2be44e-cfd5-40c2-8c08-6c8d82acfa1c" />
Etter denne endring:

<img width="636" alt="Skjermbilde 2025-02-13 kl  14 03 56" src="https://github.com/user-attachments/assets/00a307c7-f924-4556-8181-137cf0717cb3" />
