### PR TITLE
Bruk en vedlikeholdt versjon av openhtmltopdf

### DIFF
--- a/integrasjontjenester/pdfgen/pom.xml
+++ b/integrasjontjenester/pdfgen/pom.xml
@@ -26,11 +26,11 @@
             <version>${verapdf-validation-model.version}</version>
         </dependency>
         <dependency>
-            <groupId>at.datenwort.openhtmltopdf</groupId>
+            <groupId>io.github.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>at.datenwort.openhtmltopdf</groupId>
+            <groupId>io.github.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-pdfbox</artifactId>
             <exclusions>
                 <exclusion>
@@ -42,12 +42,12 @@
         </dependency>
         <dependency>
             <!-- Optional, leave out if you do not need logging via slf4j. -->
-            <groupId>at.datenwort.openhtmltopdf</groupId>
+            <groupId>io.github.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-slf4j</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>at.datenwort.openhtmltopdf</groupId>
+            <groupId>io.github.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-svg-support</artifactId>
             <exclusions>
                 <!-- denne drar inn to ulike versjoner av org.apache.xmlgraphics.xml-graphics-commons  -->

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <fp-tidsserie.version>2.7.1</fp-tidsserie.version>
 
-        <openhtmltopdf.version>1.1.4</openhtmltopdf.version>
+        <openhtmltopdf.version>1.1.24</openhtmltopdf.version>
         <handlebars.version>4.3.1</handlebars.version>
         <open.batik.version>1.18</open.batik.version>
 
@@ -363,22 +363,22 @@
             </dependency>
 
             <dependency>
-                <groupId>at.datenwort.openhtmltopdf</groupId>
+                <groupId>io.github.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-core</artifactId>
                 <version>${openhtmltopdf.version}</version>
             </dependency>
             <dependency>
-                <groupId>at.datenwort.openhtmltopdf</groupId>
+                <groupId>io.github.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-pdfbox</artifactId>
                 <version>${openhtmltopdf.version}</version>
             </dependency>
             <dependency>
-                <groupId>at.datenwort.openhtmltopdf</groupId>
+                <groupId>io.github.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-svg-support</artifactId>
                 <version>${openhtmltopdf.version}</version>
             </dependency>
             <dependency>
-                <groupId>at.datenwort.openhtmltopdf</groupId>
+                <groupId>io.github.openhtmltopdf</groupId>
                 <artifactId>openhtmltopdf-slf4j</artifactId>
                 <version>${openhtmltopdf.version}</version>
             </dependency>


### PR DESCRIPTION
Samme versjon som brukes i pdfgen - denne blir aktivt vedlikeholdt. 
Dokgen bør også bruke denne.