### PR TITLE
Flytt registrering av DynamicJacksonJsonProvider til å vere først.

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/konfig/ApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/konfig/ApiConfig.java
@@ -93,6 +93,7 @@ public class ApiConfig extends Application {
     @Override
     public Set<Class<?>> getClasses() {
         var classes = new HashSet<>(Set.of(
+            DynamicJacksonJsonProvider.class, // Denne må registrerast før anna OpenAPI oppsett for å fungere.
             // eksponert grensesnitt
             ProsessTaskRestTjeneste.class,
             InitielleLinksRestTjeneste.class,
@@ -121,7 +122,6 @@ public class ApiConfig extends Application {
             // swagger
             OpenApiTjeneste.class,
             // Applikasjonsoppsett
-            DynamicJacksonJsonProvider.class,
             JacksonJsonConfig.class,
             DynamicObjectMapperResolverVaryFilter.class,
             // ExceptionMappers pga de som finnes i Jackson+Jersey-media


### PR DESCRIPTION
Ellers får den ikkje effekt, og ObjectMapper resolver blir cacha på tvers av requests.

Oppfølging av #2963 