### PR TITLE
TFP-6113: Regresjonsfeil. Språkkode en -> EN som ble feil etter omskriving i 2020.

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/automatisksaksbehandling/AutomatiskSaksbehandlingRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/automatisksaksbehandling/AutomatiskSaksbehandlingRepository.java
@@ -33,13 +33,9 @@ public class AutomatiskSaksbehandlingRepository {
         this.entityManager = entityManager;
     }
 
-    public static Period getKravgrunnlagAlderNårGammel() {
-        return Frister.KRAVGRUNNLAG_ALDER_GAMMELT;
-    }
-
     public List<Behandling> hentAlleBehandlingerSomErKlarForAutomatiskSaksbehandling(LocalDate bestemtDato) {
 
-        var kontrollFeltFørDato = bestemtDato.minus(getKravgrunnlagAlderNårGammel());
+        var kontrollFeltFørDato = bestemtDato.minus(Frister.KRAVGRUNNLAG_ALDER_GAMMELT);
 
         TypedQuery<Behandling> query = entityManager.createQuery("""
                 from Behandling beh where beh.id in

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/fagsak/FagsakYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/fagsak/FagsakYtelseType.java
@@ -102,7 +102,7 @@ public enum FagsakYtelseType implements Kodeverdi {
     }
 
     public static String finnFagsaktypenavnPåAngittSpråk(FagsakYtelseType fagsakYtelseType, Språkkode språkkode) {
-        return Språkkode.nn.equals(språkkode) ? fagsakYtelseType.getNavnPåNynorsk() : fagsakYtelseType.getNavn();
+        return Språkkode.NN.equals(språkkode) ? fagsakYtelseType.getNavnPåNynorsk() : fagsakYtelseType.getNavn();
     }
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/geografisk/Språkkode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/geografisk/Språkkode.java
@@ -13,12 +13,12 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.kodeverk.Kodeverdi;
 
 
 public enum Språkkode implements Kodeverdi {
-    nb("NB"),
-    nn("NN"),
-    en("en"),
+    NB("NB"),
+    NN("NN"),
+    EN("EN"),
     UDEFINERT("-");
 
-    public static final Språkkode DEFAULT = Språkkode.nb;
+    public static final Språkkode DEFAULT = Språkkode.NB;
     public static final String KODEVERK = "SPRAAK_KODE";
     private static final Map<String, Språkkode> KODER = new LinkedHashMap<>();
 
@@ -32,7 +32,6 @@ public enum Språkkode implements Kodeverdi {
         }
     }
 
-
     Språkkode(String kode) {
         this.kode = kode;
     }
@@ -43,7 +42,7 @@ public enum Språkkode implements Kodeverdi {
         }
         var ad = KODER.get(kode);
         if (ad == null) {
-            return Språkkode.nb;
+            return Språkkode.NB;
         }
         return ad;
     }

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/repository/BehandlingKandidaterRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/repository/BehandlingKandidaterRepositoryTest.java
@@ -82,7 +82,7 @@ class BehandlingKandidaterRepositoryTest {
     }
 
     private Fagsak opprettFagsak(String aktørId, String saksnummer) {
-        NavBruker b = NavBruker.opprettNy(new AktørId(aktørId), Språkkode.nb);
+        NavBruker b = NavBruker.opprettNy(new AktørId(aktørId), Språkkode.NB);
         Fagsak fagsak = TestFagsakUtil.opprettFagsak(new Saksnummer(saksnummer), b);
         Long fagsakId = fagsakRepository.lagre(fagsak);
         return fagsakRepository.finnEksaktFagsak(fagsakId);

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/repository/BehandlingVenterRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/behandling/repository/BehandlingVenterRepositoryTest.java
@@ -116,7 +116,7 @@ class BehandlingVenterRepositoryTest {
     }
 
     private Fagsak opprettFagsak(String aktørId, String saksnummer) {
-        NavBruker b = NavBruker.opprettNy(new AktørId(aktørId), Språkkode.nb);
+        NavBruker b = NavBruker.opprettNy(new AktørId(aktørId), Språkkode.NB);
         Fagsak fagsak = TestFagsakUtil.opprettFagsak(new Saksnummer(saksnummer), b);
         Long fagsakId = fagsakRepository.lagre(fagsak);
         return fagsakRepository.finnEksaktFagsak(fagsakId);

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/fagsak/FagsakRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/fagsak/FagsakRepositoryTest.java
@@ -75,7 +75,7 @@ class FagsakRepositoryTest {
 
 
     private Fagsak opprettFagsak(Saksnummer saksnummer, AktørId aktørId) {
-        NavBruker bruker = NavBruker.opprettNy(aktørId, Språkkode.nb);
+        NavBruker bruker = NavBruker.opprettNy(aktørId, Språkkode.NB);
 
         // Opprett fagsak
         Fagsak fagsak = TestFagsakUtil.opprettFagsak(saksnummer, bruker);
@@ -87,7 +87,7 @@ class FagsakRepositoryTest {
 
 
     private Fagsak opprettFagsak(Saksnummer saksnummer, AktørId aktørId, Long eksternSystemId, Fagsystem eksternFagsakSystem) {
-        NavBruker bruker = NavBruker.opprettNy(aktørId, Språkkode.nb);
+        NavBruker bruker = NavBruker.opprettNy(aktørId, Språkkode.NB);
 
         // Opprett fagsak
         Fagsak fagsak = TestFagsakUtil.opprettFagsak(saksnummer, bruker);

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/test/TestFagsakUtil.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/test/TestFagsakUtil.java
@@ -29,7 +29,7 @@ public class TestFagsakUtil {
 
     public static NavBruker genererBruker() {
         AktørId aktørId = new AktørId(nyId());
-        return NavBruker.opprettNy(aktørId, Språkkode.nb);
+        return NavBruker.opprettNy(aktørId, Språkkode.NB);
     }
 
     public static Saksnummer genererSaksnummer() {

--- a/behandlingslager/testutilities/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/testutilities/kodeverk/AbstractTestScenario.java
+++ b/behandlingslager/testutilities/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/testutilities/kodeverk/AbstractTestScenario.java
@@ -79,12 +79,12 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
 
     protected AbstractTestScenario() {
         var aktørId = new AktørId(nyId());
-        var bruker = NavBruker.opprettNy(aktørId, Språkkode.nb);
+        var bruker = NavBruker.opprettNy(aktørId, Språkkode.NB);
         fagsak = lagFagsak(bruker);
     }
 
     protected AbstractTestScenario(AktørId aktørId) {
-        var bruker = NavBruker.opprettNy(aktørId, Språkkode.nb);
+        var bruker = NavBruker.opprettNy(aktørId, Språkkode.NB);
         fagsak = lagFagsak(bruker);
     }
 

--- a/behandlingslager/testutilities/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/testutilities/kodeverk/TestFagsakUtil.java
+++ b/behandlingslager/testutilities/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/testutilities/kodeverk/TestFagsakUtil.java
@@ -24,7 +24,7 @@ public class TestFagsakUtil {
 
     public static NavBruker genererBruker() {
         AktørId aktørId = new AktørId(nyId());
-        return NavBruker.opprettNy(aktørId, Språkkode.nb);
+        return NavBruker.opprettNy(aktørId, Språkkode.NB);
     }
 
     public static Saksnummer genererSaksnummer() {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/automatisksaksbehandling/AutomatiskSaksbehandlingBatchTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/automatisksaksbehandling/AutomatiskSaksbehandlingBatchTask.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.tilbakekreving.behandling.impl.KravgrunnlagBeregningTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.automatisksaksbehandling.AutomatiskSaksbehandlingRepository;
+import no.nav.foreldrepenger.tilbakekreving.felles.Frister;
 import no.nav.foreldrepenger.tilbakekreving.felles.Helligdager;
 import no.nav.foreldrepenger.tilbakekreving.grunnlag.KravgrunnlagRepository;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
@@ -60,7 +61,7 @@ public class AutomatiskSaksbehandlingBatchTask implements ProsessTaskHandler {
         if (Helligdager.erHelligdagEllerHelg(iDag)) {
             LOG.info("Kjører ikke batch {} i helgen eller helligdag. Iverksetting i saksbehandling avhenger av oppdragsystemet, som sannsynligvis har nedetid", batchRun);
         } else {
-            LocalDate loggDato = iDag.minus(AutomatiskSaksbehandlingRepository.getKravgrunnlagAlderNårGammel());
+            LocalDate loggDato = iDag.minus(Frister.KRAVGRUNNLAG_ALDER_GAMMELT);
             LOG.info("Henter behandlinger som er eldre enn {} i batch {}", loggDato, batchRun);
             List<Behandling> behandlinger = automatiskSaksbehandlingRepository.hentAlleBehandlingerSomErKlarForAutomatiskSaksbehandling(iDag);
             var opprettTaskForBehandlinger  = behandlinger.stream()

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/batch/HåndterGamleKravgrunnlagBatchTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/batch/HåndterGamleKravgrunnlagBatchTask.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.tilbakekreving.behandling.task.TaskProperties;
-import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.automatisksaksbehandling.AutomatiskSaksbehandlingRepository;
+import no.nav.foreldrepenger.tilbakekreving.felles.Frister;
 import no.nav.foreldrepenger.tilbakekreving.felles.Helligdager;
 import no.nav.foreldrepenger.tilbakekreving.økonomixml.ØkonomiMottattXmlRepository;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
@@ -42,7 +42,7 @@ public class HåndterGamleKravgrunnlagBatchTask implements ProsessTaskHandler {
         this.mottattXmlRepository = mottattXmlRepository;
         this.taskTjeneste = taskTjeneste;
         this.clock = Clock.systemDefaultZone();
-        this.alderForGammeltGrunnlag = AutomatiskSaksbehandlingRepository.getKravgrunnlagAlderNårGammel();
+        this.alderForGammeltGrunnlag = Frister.KRAVGRUNNLAG_ALDER_GAMMELT;
     }
 
     // kun for test forbruk

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/førstegang/LesKravgrunnlagTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/førstegang/LesKravgrunnlagTaskTest.java
@@ -95,7 +95,7 @@ class LesKravgrunnlagTaskTest extends FellesTestOppsett {
     }
 
     private Behandling lagBehandling() {
-        NavBruker navBruker = NavBruker.opprettNy(TestFagsakUtil.genererBruker().getAktørId(), Språkkode.nb);
+        NavBruker navBruker = NavBruker.opprettNy(TestFagsakUtil.genererBruker().getAktørId(), Språkkode.NB);
         Fagsak fagsak = Fagsak.opprettNy(new Saksnummer("139015144"), navBruker);
         fagsakRepository.lagre(fagsak);
         Behandling behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.TILBAKEKREVING).build();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/status/LesKravvedtakStatusTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/status/LesKravvedtakStatusTaskTest.java
@@ -285,7 +285,7 @@ class LesKravvedtakStatusTaskTest extends FellesTestOppsett {
     }
 
     private Behandling lagBehandling() {
-        var navBruker = NavBruker.opprettNy(TestFagsakUtil.genererBruker().getAktørId(), Språkkode.nb);
+        var navBruker = NavBruker.opprettNy(TestFagsakUtil.genererBruker().getAktørId(), Språkkode.NB);
         var fagsak = Fagsak.opprettNy(new Saksnummer("139015144"), navBruker);
         fagsakRepository.lagre(fagsak);
         var behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.TILBAKEKREVING).build();

--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/AutomatiskSaksbehandlingVurderingTjeneste.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/AutomatiskSaksbehandlingVurderingTjeneste.java
@@ -6,8 +6,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.automatisksaksbehandling.AutomatiskSaksbehandlingRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.varsel.VarselRepository;
+import no.nav.foreldrepenger.tilbakekreving.felles.Frister;
 import no.nav.foreldrepenger.tilbakekreving.grunnlag.Kravgrunnlag431;
 import no.nav.foreldrepenger.tilbakekreving.grunnlag.KravgrunnlagRepository;
 
@@ -49,7 +49,7 @@ public class AutomatiskSaksbehandlingVurderingTjeneste {
 
     public static LocalDateTime ventefristForTilfelleSomKanAutomatiskSaksbehandles(Kravgrunnlag431 kravgrunnlag) {
         return kravgrunnlag.getKontrollFeltAsLocalDate()
-            .plus(AutomatiskSaksbehandlingRepository.getKravgrunnlagAlderNårGammel())
+            .plus(Frister.KRAVGRUNNLAG_ALDER_GAMMELT)
             .plusDays(1).atStartOfDay();
     }
 

--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/BehandlingTjenesteTest.java
@@ -257,7 +257,7 @@ class BehandlingTjenesteTest extends FellesTestOppsett {
 
     private EksternBehandlingsinfoDto lagEksternBehandlingsInfo() {
         EksternBehandlingsinfoDto eksternBehandlingsinfo = new EksternBehandlingsinfoDto();
-        eksternBehandlingsinfo.setSprakkode(Språkkode.nb);
+        eksternBehandlingsinfo.setSprakkode(Språkkode.NB);
         eksternBehandlingsinfo.setUuid(eksternBehandlingUuid);
         eksternBehandlingsinfo.setHenvisning(henvisning);
         eksternBehandlingsinfo.setVedtakDato(NOW);

--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/FaktaFeilutbetalingTjenesteTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/FaktaFeilutbetalingTjenesteTest.java
@@ -214,7 +214,7 @@ class FaktaFeilutbetalingTjenesteTest extends FellesTestOppsett {
 
     private EksternBehandlingsinfoDto lagEksternBehandlingsInfo() {
         EksternBehandlingsinfoDto eksternBehandlingsinfo = new EksternBehandlingsinfoDto();
-        eksternBehandlingsinfo.setSprakkode(Språkkode.nb);
+        eksternBehandlingsinfo.setSprakkode(Språkkode.NB);
         eksternBehandlingsinfo.setUuid(eksternBehandlingUuid);
         eksternBehandlingsinfo.setVedtakDato(NOW);
 

--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/KravVedtakStatusTjenesteTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/KravVedtakStatusTjenesteTest.java
@@ -107,7 +107,7 @@ class KravVedtakStatusTjenesteTest {
 
         var behandling = Behandling.nyBehandlingFor(
             Fagsak.opprettNy(Saksnummer.infotrygd("32423432"),
-                NavBruker.opprettNy(new AktørId(233L), Språkkode.nn)), BehandlingType.TILBAKEKREVING).build();
+                NavBruker.opprettNy(new AktørId(233L), Språkkode.NN)), BehandlingType.TILBAKEKREVING).build();
 
         when(grunnlagRepository.harGrunnlagForBehandlingId(behandlingId)).thenReturn(true);
         when(grunnlagRepository.erKravgrunnlagSperret(behandlingId)).thenReturn(false);
@@ -128,7 +128,7 @@ class KravVedtakStatusTjenesteTest {
 
         var behandling = Behandling.nyBehandlingFor(
             Fagsak.opprettNy(Saksnummer.infotrygd("32423432"),
-                NavBruker.opprettNy(new AktørId(233L), Språkkode.nn)), BehandlingType.TILBAKEKREVING).build();
+                NavBruker.opprettNy(new AktørId(233L), Språkkode.NN)), BehandlingType.TILBAKEKREVING).build();
 
         when(grunnlagRepository.harGrunnlagForBehandlingId(behandlingId)).thenReturn(true);
         when(grunnlagRepository.erKravgrunnlagSperret(behandlingId)).thenReturn(false);

--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/VedtaksbrevFritekstTjenesteTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/VedtaksbrevFritekstTjenesteTest.java
@@ -57,7 +57,7 @@ class VedtaksbrevFritekstTjenesteTest {
     private final LocalDate jan3 = LocalDate.of(2019, 1, 3);
     private final LocalDate jan24 = LocalDate.of(2019, 1, 24);
 
-    private final NavBruker bruker = NavBruker.opprettNy(new AktørId(1L), Språkkode.nb);
+    private final NavBruker bruker = NavBruker.opprettNy(new AktørId(1L), Språkkode.NB);
     private final Fagsak fagsak = Fagsak.opprettNy(new Saksnummer("123"), bruker);
     private final Behandling behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.TILBAKEKREVING).build();
     private Long behandlingId;

--- a/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/VedtaksbrevFritekstValidatorTest.java
+++ b/domenetjenester/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/impl/VedtaksbrevFritekstValidatorTest.java
@@ -51,7 +51,7 @@ class VedtaksbrevFritekstValidatorTest {
     private final LocalDate jan3 = LocalDate.of(2019, 1, 3);
     private final LocalDate jan24 = LocalDate.of(2019, 1, 24);
 
-    private final NavBruker bruker = NavBruker.opprettNy(new AktørId(1L), Språkkode.nb);
+    private final NavBruker bruker = NavBruker.opprettNy(new AktørId(1L), Språkkode.NB);
     private final Fagsak fagsak = Fagsak.opprettNy(new Saksnummer("123"), bruker);
     private final Behandling behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.TILBAKEKREVING).build();
     private final Behandling revurderingBehandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.REVURDERING_TILBAKEKREVING).build();

--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/felles/EksternDataForBrevTjeneste.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/felles/EksternDataForBrevTjeneste.java
@@ -85,7 +85,7 @@ public class EksternDataForBrevTjeneste {
         String ytelsePåBokmål = ytelsetype.getNavn().toLowerCase();
         ytelseNavn.setNavnPåBokmål(ytelsePåBokmål);
 
-        if (språkkode != null && !språkkode.equals(Språkkode.nb)) {
+        if (språkkode != null && !språkkode.equals(Språkkode.NB)) {
             ytelseNavn.setNavnPåBrukersSpråk(FagsakYtelseType.finnFagsaktypenavnPåAngittSpråk(ytelsetype, språkkode).toLowerCase());
         } else {
             ytelseNavn.setNavnPåBrukersSpråk(ytelsePåBokmål);

--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/handlebars/FellesTekstformaterer.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/handlebars/FellesTekstformaterer.java
@@ -87,7 +87,7 @@ public abstract class FellesTekstformaterer {
     }
 
     private static String mapTilSpråk(Språkkode språkkode) {
-        if (Språkkode.nn.equals(språkkode)) {
+        if (Språkkode.NN.equals(språkkode)) {
             return "nn";
         } else {
             return "nb";

--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtakHjemmel.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtakHjemmel.java
@@ -118,12 +118,12 @@ public class VedtakHjemmel {
 
         Hjemler(String bokmål, String nynorsk) {
             hjemmelTekster = new HashMap<>();
-            hjemmelTekster.put(Språkkode.nb, bokmål);
-            hjemmelTekster.put(Språkkode.nn, nynorsk);
+            hjemmelTekster.put(Språkkode.NB, bokmål);
+            hjemmelTekster.put(Språkkode.NN, nynorsk);
         }
 
         String hjemmelTekst(Språkkode språkkode) {
-            return hjemmelTekster.getOrDefault(språkkode, hjemmelTekster.get(Språkkode.nb));
+            return hjemmelTekster.getOrDefault(språkkode, hjemmelTekster.get(Språkkode.NB));
         }
     }
 }

--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/handlebars/dto/HbVedtaksbrevFelles.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/handlebars/dto/HbVedtaksbrevFelles.java
@@ -37,7 +37,7 @@ public class HbVedtaksbrevFelles implements HandlebarsData {
     private boolean finnesVerge;
     @JsonProperty("annenMottakerNavn")
     private String annenMottakerNavn;
-    private Språkkode språkkode = Språkkode.nb;
+    private Språkkode språkkode = Språkkode.NB;
     @JsonProperty("feilutbetalt-beløp-er-korrigert-ned")
     private boolean erFeilutbetaltBeløpKorrigertNed;
     @JsonProperty("totalt-feilutbetalt-beløp")

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/henleggelse/HenleggelsesbrevTjenesteTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/henleggelse/HenleggelsesbrevTjenesteTest.java
@@ -66,15 +66,15 @@ class HenleggelsesbrevTjenesteTest extends DokumentBestillerTestOppsett {
 
         when(mockPdfBrevTjeneste.genererForhåndsvisning(any(BrevData.class))).thenReturn(varselTekst.getBytes());
 
-        when(mockEksternDataForBrevTjeneste.hentYtelsenavn(FagsakYtelseType.FORELDREPENGER, Språkkode.nb))
+        when(mockEksternDataForBrevTjeneste.hentYtelsenavn(FagsakYtelseType.FORELDREPENGER, Språkkode.NB))
                 .thenReturn(lagYtelseNavn("foreldrepenger", "foreldrepenger"));
-        Personinfo personinfo = byggStandardPerson("Fiona", DUMMY_FØDSELSNUMMER, Språkkode.nn);
+        Personinfo personinfo = byggStandardPerson("Fiona", DUMMY_FØDSELSNUMMER, Språkkode.NN);
         String aktørId = behandling.getAktørId().getId();
         when(mockEksternDataForBrevTjeneste.hentPerson(any(), eq(aktørId))).thenReturn(personinfo);
         when(mockEksternDataForBrevTjeneste.hentAdresse(any(), any(Personinfo.class), any(BrevMottaker.class), any(Optional.class))).thenReturn(lagStandardNorskAdresse());
 
         EksternBehandlingsinfoDto eksternBehandlingsinfoDto = new EksternBehandlingsinfoDto();
-        eksternBehandlingsinfoDto.setSprakkode(Språkkode.nb);
+        eksternBehandlingsinfoDto.setSprakkode(Språkkode.NB);
         when(mockEksternDataForBrevTjeneste.hentYtelsesbehandlingFraFagsystemet(FPSAK_BEHANDLING_UUID))
                 .thenReturn(SamletEksternBehandlingInfo.builder()
                         .setGrunninformasjon(eksternBehandlingsinfoDto)

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/henleggelse/TekstformatererHenleggelsesbrevTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/henleggelse/TekstformatererHenleggelsesbrevTest.java
@@ -27,7 +27,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .build();
@@ -45,7 +45,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktypenavnPåSpråk(FagsakYtelseType.FRISINN.getNavn().toLowerCase())
                 .medFagsaktype(FagsakYtelseType.FRISINN)
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .build();
@@ -63,7 +63,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .medBehandlingtype(BehandlingType.REVURDERING_TILBAKEKREVING)
@@ -82,7 +82,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktypenavnPåSpråk(FagsakYtelseType.FRISINN.getNavn().toLowerCase())
                 .medFagsaktype(FagsakYtelseType.FRISINN)
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .medBehandlingtype(BehandlingType.REVURDERING_TILBAKEKREVING)
@@ -101,7 +101,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .medVergeNavn("John Doe")
@@ -122,7 +122,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .medVergeNavn("John Doe")
@@ -144,7 +144,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepengar")
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .build();
@@ -162,7 +162,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepengar")
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
                 .medBehandlingtype(BehandlingType.REVURDERING_TILBAKEKREVING)
@@ -181,7 +181,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .build();
 
         HenleggelsesbrevSamletInfo henleggelsesbrevSamletInfo = new HenleggelsesbrevSamletInfo();
@@ -197,7 +197,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medBehandlingtype(BehandlingType.REVURDERING_TILBAKEKREVING)
                 .build();
 
@@ -214,7 +214,7 @@ class TekstformatererHenleggelsesbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .build();
 
         HenleggelsesbrevSamletInfo henleggelsesbrevSamletInfo = new HenleggelsesbrevSamletInfo();

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/innhentdokumentasjon/InnhentDokumentasjonbrevTjenesteTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/innhentdokumentasjon/InnhentDokumentasjonbrevTjenesteTest.java
@@ -44,16 +44,16 @@ class InnhentDokumentasjonbrevTjenesteTest extends DokumentBestillerTestOppsett 
 
         when(mockPdfBrevTjeneste.genererForhåndsvisning(any(BrevData.class))).thenReturn(FLERE_OPPLYSNINGER.getBytes());
 
-        when(mockEksternDataForBrevTjeneste.hentYtelsenavn(FagsakYtelseType.FORELDREPENGER, Språkkode.nb))
+        when(mockEksternDataForBrevTjeneste.hentYtelsenavn(FagsakYtelseType.FORELDREPENGER, Språkkode.NB))
                 .thenReturn(lagYtelseNavn("foreldrepenger", "foreldrepenger"));
-        Personinfo personinfo = byggStandardPerson("Fiona", DUMMY_FØDSELSNUMMER, Språkkode.nn);
+        Personinfo personinfo = byggStandardPerson("Fiona", DUMMY_FØDSELSNUMMER, Språkkode.NN);
         String aktørId = behandling.getAktørId().getId();
         when(mockEksternDataForBrevTjeneste.hentPerson(any(), eq(aktørId))).thenReturn(personinfo);
         when(mockEksternDataForBrevTjeneste.hentAdresse(any(), any(Personinfo.class), any(BrevMottaker.class), any(Optional.class)))
                 .thenReturn(lagStandardNorskAdresse());
 
         EksternBehandlingsinfoDto eksternBehandlingsinfoDto = new EksternBehandlingsinfoDto();
-        eksternBehandlingsinfoDto.setSprakkode(Språkkode.nb);
+        eksternBehandlingsinfoDto.setSprakkode(Språkkode.NB);
         when(mockEksternDataForBrevTjeneste.hentYtelsesbehandlingFraFagsystemet(FPSAK_BEHANDLING_UUID))
                 .thenReturn(SamletEksternBehandlingInfo.builder()
                         .setGrunninformasjon(eksternBehandlingsinfoDto)

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/innhentdokumentasjon/TekstformatererInnhentDokumentasjonbrevTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/innhentdokumentasjon/TekstformatererInnhentDokumentasjonbrevTest.java
@@ -23,7 +23,7 @@ class TekstformatererInnhentDokumentasjonbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagStandardNorskAdresse())
                 .medSakspartNavn("Test")
                 .build();
@@ -44,7 +44,7 @@ class TekstformatererInnhentDokumentasjonbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktypenavnPåSpråk(FagsakYtelseType.FRISINN.getNavn().toLowerCase())
                 .medFagsaktype(FagsakYtelseType.FRISINN)
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagStandardNorskAdresse())
                 .medSakspartNavn("Test")
                 .build();
@@ -65,7 +65,7 @@ class TekstformatererInnhentDokumentasjonbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(lagStandardNorskAdresse())
                 .medSakspartNavn("Test")
                 .medVergeNavn("John Doe")
@@ -91,7 +91,7 @@ class TekstformatererInnhentDokumentasjonbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medMottakerAdresse(orgAdresse)
                 .medSakspartNavn("Test")
                 .medVergeNavn("John Doe")
@@ -115,7 +115,7 @@ class TekstformatererInnhentDokumentasjonbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .medMottakerAdresse(lagStandardNorskAdresse())
                 .medSakspartNavn("Test")
                 .build();
@@ -136,7 +136,7 @@ class TekstformatererInnhentDokumentasjonbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .build();
 
         InnhentDokumentasjonbrevSamletInfo innhentDokumentasjonBrevSamletInfo = InnhentDokumentasjonbrevSamletInfo.builder()
@@ -152,7 +152,7 @@ class TekstformatererInnhentDokumentasjonbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FORELDREPENGER)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .build();
 
         InnhentDokumentasjonbrevSamletInfo innhentDokumentasjonBrevSamletInfo = InnhentDokumentasjonbrevSamletInfo.builder()

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/varsel/TekstformatererVarselbrevTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/varsel/TekstformatererVarselbrevTest.java
@@ -35,7 +35,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_varseltekst_for_flere_perioder() throws Exception {
         BrevMetadata metadata = new BrevMetadata.Builder()
                 .medFagsaktype(svangerskapspengerkode)
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .medFagsaktypenavnPåSpråk("svangerskapspengar")
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
@@ -60,7 +60,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_varseltekst_for_engangsstønad() throws IOException {
         BrevMetadata metadata = new BrevMetadata.Builder()
                 .medFagsaktype(engangsstønadkode)
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medFagsaktypenavnPåSpråk("eingongsstønad")
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
@@ -85,7 +85,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_varseltekst_for_foreldrepenger_med_enkelt_periode() throws IOException {
         BrevMetadata metadata = new BrevMetadata.Builder()
                 .medFagsaktype(foreldrepengerkode)
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
@@ -110,7 +110,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_varseltekst_for_frisinn_med_enkelt_periode() throws IOException {
         BrevMetadata metadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.FRISINN)
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medFagsaktypenavnPåSpråk(FagsakYtelseType.FRISINN.getNavn().toLowerCase())
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
@@ -134,7 +134,7 @@ class TekstformatererVarselbrevTest {
     @Test
     void skal_mappe_verdier_fra_dtoer_til_komplett_tilbakekrevingsvarsel() {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .medFagsaktype(foreldrepengerkode)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
                 .medMottakerAdresse(lagAdresseInfo())
@@ -166,7 +166,7 @@ class TekstformatererVarselbrevTest {
     void skal_ikke_sette_tidligste_og_seneste_dato_når_det_foreligger_flere_perioder() {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(foreldrepengerkode)
-                .medSprakkode(Språkkode.en)
+                .medSprakkode(Språkkode.EN)
                 .medFagsaktypenavnPåSpråk("foreldrepengar")
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")
@@ -223,7 +223,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_varselbrev_overskrift() {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .build();
 
         String overskrift = TekstformatererVarselbrev.lagVarselbrevOverskrift(brevMetadata);
@@ -235,7 +235,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_varselbrev_overskrift_nynorsk() {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktypenavnPåSpråk("foreldrepengar")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .build();
 
         String overskrift = TekstformatererVarselbrev.lagVarselbrevOverskrift(brevMetadata);
@@ -247,7 +247,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_korrigert_varselbrev_overskrift() {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .build();
 
         String overskrift = TekstformatererVarselbrev.lagKorrigertVarselbrevOverskrift(brevMetadata);
@@ -259,7 +259,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_korrigert_varselbrev_overskrift_nynorsk() {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktypenavnPåSpråk("foreldrepengar")
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .build();
 
         String overskrift = TekstformatererVarselbrev.lagKorrigertVarselbrevOverskrift(brevMetadata);
@@ -272,7 +272,7 @@ class TekstformatererVarselbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.ENGANGSTØNAD)
                 .medFagsaktypenavnPåSpråk("engangstønad")
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .build();
 
         String overskrift = TekstformatererVarselbrev.lagKorrigertVarselbrevOverskrift(brevMetadata);
@@ -285,7 +285,7 @@ class TekstformatererVarselbrevTest {
         BrevMetadata brevMetadata = new BrevMetadata.Builder()
                 .medFagsaktype(FagsakYtelseType.ENGANGSTØNAD)
                 .medFagsaktypenavnPåSpråk("eingongstønad")
-                .medSprakkode(Språkkode.nn)
+                .medSprakkode(Språkkode.NN)
                 .build();
 
         String overskrift = TekstformatererVarselbrev.lagKorrigertVarselbrevOverskrift(brevMetadata);
@@ -297,7 +297,7 @@ class TekstformatererVarselbrevTest {
     void skal_generere_varselbrev_for_verge() throws IOException {
         BrevMetadata metadata = new BrevMetadata.Builder()
                 .medFagsaktype(foreldrepengerkode)
-                .medSprakkode(Språkkode.nb)
+                .medSprakkode(Språkkode.NB)
                 .medFagsaktypenavnPåSpråk("foreldrepenger")
                 .medMottakerAdresse(lagAdresseInfo())
                 .medSakspartNavn("Test")

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/varsel/VarselbrevUtilTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/varsel/VarselbrevUtilTest.java
@@ -48,7 +48,7 @@ class VarselbrevUtilTest {
         EksternBehandlingsinfoDto eksternBehandlingsinfoDto = new EksternBehandlingsinfoDto();
         eksternBehandlingsinfoDto.setBehandlendeEnhetId(BEHANDLENDE_ENHET_ID);
         eksternBehandlingsinfoDto.setBehandlendeEnhetNavn(BEHANDLENDE_ENHET_NAVN);
-        eksternBehandlingsinfoDto.setSprakkode(Språkkode.nn);
+        eksternBehandlingsinfoDto.setSprakkode(Språkkode.NN);
 
         Adresseinfo adresseinfo = lagStandardNorskAdresse();
 
@@ -104,7 +104,7 @@ class VarselbrevUtilTest {
         EksternBehandlingsinfoDto eksternBehandlingsinfoDto = new EksternBehandlingsinfoDto();
         eksternBehandlingsinfoDto.setBehandlendeEnhetId(BEHANDLENDE_ENHET_ID);
         eksternBehandlingsinfoDto.setBehandlendeEnhetNavn(BEHANDLENDE_ENHET_NAVN);
-        eksternBehandlingsinfoDto.setSprakkode(Språkkode.nn);
+        eksternBehandlingsinfoDto.setSprakkode(Språkkode.NN);
 
         YtelseNavn ytelseNavn = lagYtelseNavn("svangerskapspengar", "svangerskapspenger");
 
@@ -133,7 +133,7 @@ class VarselbrevUtilTest {
         assertThat(varselbrev.getFritekstFraSaksbehandler()).isEqualTo(VARSEL_TEKST);
         assertThat(varselbrev.getBrevMetadata().getSaksnummer()).isEqualTo("11111111");
         assertThat(varselbrev.getBrevMetadata().getAnsvarligSaksbehandler()).isEqualTo("VL");
-        assertThat(varselbrev.getBrevMetadata().getSpråkkode()).isEqualTo(Språkkode.nn);
+        assertThat(varselbrev.getBrevMetadata().getSpråkkode()).isEqualTo(Språkkode.NN);
         assertThat(varselbrev.getSumFeilutbetaling()).isEqualTo(feilutbetaltePerioderDto.sumFeilutbetaling());
         assertThat(varselbrev.getBrevMetadata().getFagsaktypenavnPåSpråk()).isEqualTo("svangerskapspengar");
         assertThat(varselbrev.getBrevMetadata().getTittel()).isEqualTo("Varsel tilbakebetaling svangerskapspenger");
@@ -164,7 +164,7 @@ class VarselbrevUtilTest {
                 .build();
 
         Saksnummer saksnummer = new Saksnummer("11111111");
-        NavBruker navBruker = NavBruker.opprettNy(new AktørId("1232132423"), Språkkode.nb);
+        NavBruker navBruker = NavBruker.opprettNy(new AktørId("1232132423"), Språkkode.NB);
         Fagsak fagsak = Fagsak.opprettNy(saksnummer, navBruker);
         Behandling behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.TILBAKEKREVING).build();
         OrganisasjonsEnhet organisasjonsEnhet = new OrganisasjonsEnhet(BEHANDLENDE_ENHET_ID, BEHANDLENDE_ENHET_NAVN);
@@ -178,7 +178,7 @@ class VarselbrevUtilTest {
                 personinfo,
                 adresseinfo,
                 FagsakYtelseType.FORELDREPENGER,
-                Språkkode.nb,
+                Språkkode.NB,
                 ytelseNavn,
                 Period.ofWeeks(3),
                 VARSEL_TEKST,
@@ -193,7 +193,7 @@ class VarselbrevUtilTest {
         assertThat(varselbrev.getFritekstFraSaksbehandler()).isEqualTo(VARSEL_TEKST);
         assertThat(varselbrev.getBrevMetadata().getSaksnummer()).isEqualTo("11111111");
         assertThat(varselbrev.getBrevMetadata().getAnsvarligSaksbehandler()).isEqualTo("VL");
-        assertThat(varselbrev.getBrevMetadata().getSpråkkode()).isEqualTo(Språkkode.nb);
+        assertThat(varselbrev.getBrevMetadata().getSpråkkode()).isEqualTo(Språkkode.NB);
         assertThat(varselbrev.getSumFeilutbetaling()).isEqualTo(feilutbetalingFakta.getAktuellFeilUtbetaltBeløp().longValue());
         assertThat(varselbrev.getBrevMetadata().getFagsaktypenavnPåSpråk()).isEqualTo("foreldrepenger");
         assertThat(varselbrev.getBrevMetadata().getTittel()).isEqualTo("Varsel tilbakebetaling foreldrepenger");

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/varsel/manuelt/ManueltVarselBrevTjenesteTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/varsel/manuelt/ManueltVarselBrevTjenesteTest.java
@@ -60,15 +60,15 @@ class ManueltVarselBrevTjenesteTest extends DokumentBestillerTestOppsett {
         behandlingId = behandling.getId();
         when(mockFeilutbetalingTjeneste.hentBehandlingFeilutbetalingFakta(behandlingId)).thenReturn(lagFeilutbetalingFakta());
 
-        when(mockEksternDataForBrevTjeneste.hentYtelsenavn(FagsakYtelseType.FORELDREPENGER, Språkkode.nb))
+        when(mockEksternDataForBrevTjeneste.hentYtelsenavn(FagsakYtelseType.FORELDREPENGER, Språkkode.NB))
                 .thenReturn(lagYtelseNavn("foreldrepenger", "foreldrepenger"));
-        Personinfo personinfo = byggStandardPerson("Fiona", DUMMY_FØDSELSNUMMER, Språkkode.nn);
+        Personinfo personinfo = byggStandardPerson("Fiona", DUMMY_FØDSELSNUMMER, Språkkode.NN);
         String aktørId = behandling.getAktørId().getId();
         when(mockEksternDataForBrevTjeneste.hentPerson(any(), eq(aktørId))).thenReturn(personinfo);
         when(mockEksternDataForBrevTjeneste.hentAdresse(any(), any(Personinfo.class), any(BrevMottaker.class), any(Optional.class))).thenReturn(lagStandardNorskAdresse());
 
         EksternBehandlingsinfoDto eksternBehandlingsinfoDto = new EksternBehandlingsinfoDto();
-        eksternBehandlingsinfoDto.setSprakkode(Språkkode.nb);
+        eksternBehandlingsinfoDto.setSprakkode(Språkkode.NB);
         when(mockEksternDataForBrevTjeneste.hentYtelsesbehandlingFraFagsystemet(FPSAK_BEHANDLING_UUID))
                 .thenReturn(SamletEksternBehandlingInfo.builder()
                         .setGrunninformasjon(eksternBehandlingsinfoDto)

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorPeriodeFaktaTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorPeriodeFaktaTest.java
@@ -69,7 +69,7 @@ class DokumentasjonGeneratorPeriodeFaktaTest {
                         .medErFødsel(true)
                         .medAntallBarn(1)
                         .build())
-                .medSpråkkode(Språkkode.nn)
+                .medSpråkkode(Språkkode.NN)
                 .build();
         var resultat = lagFaktatekster(felles);
         prettyPrint(resultat);
@@ -96,7 +96,7 @@ class DokumentasjonGeneratorPeriodeFaktaTest {
                         .medErFødsel(true)
                         .medAntallBarn(1)
                         .build())
-                .medSpråkkode(Språkkode.nn)
+                .medSpråkkode(Språkkode.NN)
                 .build();
         var resultat = lagFaktatekster(felles);
         prettyPrint(resultat);
@@ -123,7 +123,7 @@ class DokumentasjonGeneratorPeriodeFaktaTest {
                         .medErFødsel(true)
                         .medAntallBarn(1)
                         .build())
-                .medSpråkkode(Språkkode.nn)
+                .medSpråkkode(Språkkode.NN)
                 .build();
         var resultat = lagFaktatekster(felles);
         prettyPrint(resultat);
@@ -150,7 +150,7 @@ class DokumentasjonGeneratorPeriodeFaktaTest {
                         .medErFødsel(true)
                         .medAntallBarn(1)
                         .build())
-                .medSpråkkode(Språkkode.nn)
+                .medSpråkkode(Språkkode.NN)
                 .build();
         var resultat = lagFaktatekster(felles);
         prettyPrint(resultat);

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorPeriodeSærligeGrunnerTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorPeriodeSærligeGrunnerTest.java
@@ -50,7 +50,7 @@ class DokumentasjonGeneratorPeriodeSærligeGrunnerTest {
 
     @Test
     void list_ut_særlige_grunner_simpel_uaktsomhet_forstod_nynorsk() {
-        var felles = lagFellesdel(Språkkode.nn);
+        var felles = lagFellesdel(Språkkode.NN);
         lagSærligeGrunnerTekster(felles, VilkårResultat.FORSTO_BURDE_FORSTÅTT, Aktsomhet.SIMPEL_UAKTSOM);
     }
 
@@ -62,7 +62,7 @@ class DokumentasjonGeneratorPeriodeSærligeGrunnerTest {
 
     @Test
     void list_ut_særlige_grunner_grov_uaktsomhet_forstod_nynorsk() {
-        var felles = lagFellesdel(Språkkode.nn);
+        var felles = lagFellesdel(Språkkode.NN);
         lagSærligeGrunnerTekster(felles, VilkårResultat.FORSTO_BURDE_FORSTÅTT, Aktsomhet.GROVT_UAKTSOM);
     }
 
@@ -74,7 +74,7 @@ class DokumentasjonGeneratorPeriodeSærligeGrunnerTest {
 
     @Test
     void list_ut_særlige_grunner_simpel_uaktsomhet_feil_mangelfulle_opplysninger_nynorsk() {
-        var felles = lagFellesdel(Språkkode.nn);
+        var felles = lagFellesdel(Språkkode.NN);
         lagSærligeGrunnerTekster(felles, VilkårResultat.FEIL_OPPLYSNINGER_FRA_BRUKER, Aktsomhet.SIMPEL_UAKTSOM);
     }
 
@@ -86,7 +86,7 @@ class DokumentasjonGeneratorPeriodeSærligeGrunnerTest {
 
     @Test
     void list_ut_særlige_grunner_grov_uaktsomhet_feil_mangelfulle_opplysninger_nynorsk() {
-        var felles = lagFellesdel(Språkkode.nn);
+        var felles = lagFellesdel(Språkkode.NN);
         lagSærligeGrunnerTekster(felles, VilkårResultat.MANGELFULLE_OPPLYSNINGER_FRA_BRUKER, Aktsomhet.GROVT_UAKTSOM);
     }
 
@@ -206,7 +206,7 @@ class DokumentasjonGeneratorPeriodeSærligeGrunnerTest {
                         .medNavn("Søker Søkersen")
                         .medErGift(true)
                         .build())
-                .medSpråkkode(språkkode != null ? språkkode : Språkkode.nb)
+                .medSpråkkode(språkkode != null ? språkkode : Språkkode.NB)
                 .build();
     }
 

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorPeriodeVilkårTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorPeriodeVilkårTest.java
@@ -62,42 +62,42 @@ class DokumentasjonGeneratorPeriodeVilkårTest {
 
     @Test
     void generer_vilkår_for_fp() {
-        lagVilkårstekster(FagsakYtelseType.FORELDREPENGER, Språkkode.nb);
+        lagVilkårstekster(FagsakYtelseType.FORELDREPENGER, Språkkode.NB);
     }
 
     @Test
     void generer_vilkår_for_fp_nynorsk() {
-        lagVilkårstekster(FagsakYtelseType.FORELDREPENGER, Språkkode.nn);
+        lagVilkårstekster(FagsakYtelseType.FORELDREPENGER, Språkkode.NN);
     }
 
     @Test
     void generer_vilkår_for_svp() {
-        lagVilkårstekster(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.nb);
+        lagVilkårstekster(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.NB);
     }
 
     @Test
     void generer_vilkår_for_svp_nynorsk() {
-        lagVilkårstekster(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.nn);
+        lagVilkårstekster(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.NN);
     }
 
     @Test
     void generer_vilkår_for_es() {
-        lagVilkårstekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.nb);
+        lagVilkårstekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.NB);
     }
 
     @Test
     void generer_vilkår_for_es_nynorsk() {
-        lagVilkårstekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.nn);
+        lagVilkårstekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.NN);
     }
 
     @Test
     void generer_vilkår_for_frisinn() {
-        lagVilkårstekster(FagsakYtelseType.FRISINN, Språkkode.nb);
+        lagVilkårstekster(FagsakYtelseType.FRISINN, Språkkode.NB);
     }
 
     @Test
     void generer_vilkår_for_frisinn_nynorsk() {
-        lagVilkårstekster(FagsakYtelseType.FRISINN, Språkkode.nn);
+        lagVilkårstekster(FagsakYtelseType.FRISINN, Språkkode.NN);
     }
 
     private void lagVilkårstekster(FagsakYtelseType ytelsetype, Språkkode språkkode) {

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorVedtakOppsummeringTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorVedtakOppsummeringTest.java
@@ -45,7 +45,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_fp() {
         var ytelseType = FagsakYtelseType.FORELDREPENGER;
-        var nb = Språkkode.nb;
+        var nb = Språkkode.NB;
         for (var resultatType : tilbakekrevingsResultat) {
             for (var medVarsel : trueFalse) {
                 listVedtakStartAllePermutasjoner(ytelseType, nb, resultatType, medVarsel);
@@ -57,7 +57,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_fp_nynorsk() {
         var ytelseType = FagsakYtelseType.FORELDREPENGER;
-        var språkkode = Språkkode.nn;
+        var språkkode = Språkkode.NN;
         for (var resultatType : tilbakekrevingsResultat) {
             for (boolean medVarsel : trueFalse) {
                 listVedtakStartAllePermutasjoner(ytelseType, språkkode, resultatType, medVarsel);
@@ -69,7 +69,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_es() {
         var ytelseType = FagsakYtelseType.ENGANGSTØNAD;
-        var nb = Språkkode.nb;
+        var nb = Språkkode.NB;
         for (var resultatType : tilbakekrevingsResultat) {
             for (var medVarsel : trueFalse) {
                 listVedtakStartUtenSkatt(ytelseType, nb, resultatType, medVarsel);
@@ -81,7 +81,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_es_nynorsk() {
         var ytelseType = FagsakYtelseType.ENGANGSTØNAD;
-        var språkkode = Språkkode.nn;
+        var språkkode = Språkkode.NN;
         for (var resultatType : tilbakekrevingsResultat) {
             for (var medVarsel : trueFalse) {
                 listVedtakStartUtenSkatt(ytelseType, språkkode, resultatType, medVarsel);
@@ -93,7 +93,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_svp() {
         var ytelseType = FagsakYtelseType.SVANGERSKAPSPENGER;
-        var nb = Språkkode.nb;
+        var nb = Språkkode.NB;
         for (var resultatType : tilbakekrevingsResultat) {
             for (var medVarsel : trueFalse) {
                 listVedtakStartAllePermutasjoner(ytelseType, nb, resultatType, medVarsel);
@@ -105,7 +105,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_svp_nynorsk() {
         var ytelseType = FagsakYtelseType.SVANGERSKAPSPENGER;
-        var språkkode = Språkkode.nn;
+        var språkkode = Språkkode.NN;
         for (var resultatType : tilbakekrevingsResultat) {
             for (var medVarsel : trueFalse) {
                 listVedtakStartAllePermutasjoner(ytelseType, språkkode, resultatType, medVarsel);
@@ -117,7 +117,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_frisinn() {
         var ytelseType = FagsakYtelseType.FRISINN;
-        var nb = Språkkode.nb;
+        var nb = Språkkode.NB;
         for (var resultatType : tilbakekrevingsResultat) {
             for (var medVarsel : trueFalse) {
                 listVedtakStartUtenRenter(ytelseType, nb, resultatType, medVarsel);
@@ -129,7 +129,7 @@ class DokumentasjonGeneratorVedtakOppsummeringTest {
     @Test
     void list_ut_vedtak_start_for_frisinn_nynorsk() {
         var ytelseType = FagsakYtelseType.FRISINN;
-        var språkkode = Språkkode.nn;
+        var språkkode = Språkkode.NN;
         for (var resultatType : tilbakekrevingsResultat) {
             for (var medVarsel : trueFalse) {
                 listVedtakStartUtenRenter(ytelseType, språkkode, resultatType, medVarsel);

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorVedtakSluttTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/DokumentasjonGeneratorVedtakSluttTest.java
@@ -56,8 +56,8 @@ class DokumentasjonGeneratorVedtakSluttTest {
 
     @Test
     void list_ut_vedtak_slutt_nn() {
-        lagVedtakSluttTekster(FagsakYtelseType.FORELDREPENGER, Språkkode.nn, VedtakResultatType.FULL_TILBAKEBETALING);
-        lagVedtakSluttTekster(FagsakYtelseType.FORELDREPENGER, Språkkode.nn, VedtakResultatType.INGEN_TILBAKEBETALING);
+        lagVedtakSluttTekster(FagsakYtelseType.FORELDREPENGER, Språkkode.NN, VedtakResultatType.FULL_TILBAKEBETALING);
+        lagVedtakSluttTekster(FagsakYtelseType.FORELDREPENGER, Språkkode.NN, VedtakResultatType.INGEN_TILBAKEBETALING);
     }
 
     @Test
@@ -68,8 +68,8 @@ class DokumentasjonGeneratorVedtakSluttTest {
 
     @Test
     void list_ut_vedtak_slutt_es_nn() {
-        lagVedtakSluttTekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.nn, VedtakResultatType.FULL_TILBAKEBETALING, false);
-        lagVedtakSluttTekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.nn, VedtakResultatType.INGEN_TILBAKEBETALING, false);
+        lagVedtakSluttTekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.NN, VedtakResultatType.FULL_TILBAKEBETALING, false);
+        lagVedtakSluttTekster(FagsakYtelseType.ENGANGSTØNAD, Språkkode.NN, VedtakResultatType.INGEN_TILBAKEBETALING, false);
     }
 
     @Test
@@ -80,8 +80,8 @@ class DokumentasjonGeneratorVedtakSluttTest {
 
     @Test
     void list_ut_vedtak_slutt_frisinn_nn() {
-        lagVedtakSluttTekster(FagsakYtelseType.FRISINN, Språkkode.nn, VedtakResultatType.FULL_TILBAKEBETALING, false);
-        lagVedtakSluttTekster(FagsakYtelseType.FRISINN, Språkkode.nn, VedtakResultatType.INGEN_TILBAKEBETALING, false);
+        lagVedtakSluttTekster(FagsakYtelseType.FRISINN, Språkkode.NN, VedtakResultatType.FULL_TILBAKEBETALING, false);
+        lagVedtakSluttTekster(FagsakYtelseType.FRISINN, Språkkode.NN, VedtakResultatType.INGEN_TILBAKEBETALING, false);
     }
 
     private void lagVedtakSluttTekster(FagsakYtelseType ytelsetype, Språkkode språkkode, VedtakResultatType resultatType) {
@@ -156,7 +156,7 @@ class DokumentasjonGeneratorVedtakSluttTest {
                         .medErGift(true)
                         .build())
                 .medVedtaksbrevType(feilutbetaltBeløpBortfalt ? VedtaksbrevType.FRITEKST_FEILUTBETALING_BORTFALT : VedtaksbrevType.ORDINÆR)
-                .medSpråkkode(språkkode != null ? språkkode : Språkkode.nb);
+                .medSpråkkode(språkkode != null ? språkkode : Språkkode.NB);
         if (erRevurdering) {
             builder
                     .medBehandling(HbBehandling.builder()

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest.java
@@ -44,26 +44,26 @@ class TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest {
 
     @Test
     void skal_støtte_alle_permutasjoner_av_fakta_for_FP() {
-        lagTeksterOgValider(FagsakYtelseType.FORELDREPENGER, Språkkode.nb);
+        lagTeksterOgValider(FagsakYtelseType.FORELDREPENGER, Språkkode.NB);
     }
 
     @Test
     void skal_støtte_alle_permutasjoner_av_fakta_for_FP_nynorsk() {
-        lagTeksterOgValider(FagsakYtelseType.FORELDREPENGER, Språkkode.nn);
+        lagTeksterOgValider(FagsakYtelseType.FORELDREPENGER, Språkkode.NN);
     }
 
     @Test
     void skal_støtte_alle_permutasjoner_av_fakta_for_SVP() {
         var unntak1 = Set.of(new HendelseMedUndertype(HendelseType.SVP_ARBEIDSGIVERS_FORHOLD_TYPE, HendelseUnderType.SVP_TILRETTELEGGING_FULLT_MULIG), new HendelseMedUndertype(HendelseType.SVP_ARBEIDSGIVERS_FORHOLD_TYPE, HendelseUnderType.SVP_TILRETTELEGGING_DELVIS_MULIG));
 
-        lagTeksterOgValider(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.nb, unntak1);
+        lagTeksterOgValider(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.NB, unntak1);
     }
 
     @Test
     void skal_støtte_alle_permutasjoner_av_fakta_for_SVP_nynorsk() {
         var unntak1 = Set.of(new HendelseMedUndertype(HendelseType.SVP_ARBEIDSGIVERS_FORHOLD_TYPE, HendelseUnderType.SVP_TILRETTELEGGING_FULLT_MULIG), new HendelseMedUndertype(HendelseType.SVP_ARBEIDSGIVERS_FORHOLD_TYPE, HendelseUnderType.SVP_TILRETTELEGGING_DELVIS_MULIG));
 
-        lagTeksterOgValider(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.nn, unntak1);
+        lagTeksterOgValider(FagsakYtelseType.SVANGERSKAPSPENGER, Språkkode.NN, unntak1);
     }
 
     @Test
@@ -71,7 +71,7 @@ class TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest {
         var unntak1 = Set.of(new HendelseMedUndertype(HendelseType.ES_FORELDREANSVAR_TYPE, HendelseUnderType.ES_IKKE_TILDELT), new HendelseMedUndertype(HendelseType.ES_FORELDREANSVAR_TYPE, HendelseUnderType.ES_ANDRE_FORELDRE_DODD));
         var unntak2 = Set.of(new HendelseMedUndertype(HendelseType.ES_ADOPSJONSVILKAARET_TYPE, HendelseUnderType.ES_BARN_OVER_15), new HendelseMedUndertype(HendelseType.ES_FORELDREANSVAR_TYPE, HendelseUnderType.ES_FORELDREANSVAR_BARN_OVER_15));
 
-        lagTeksterOgValider(FagsakYtelseType.ENGANGSTØNAD, Språkkode.nb, unntak1, unntak2);
+        lagTeksterOgValider(FagsakYtelseType.ENGANGSTØNAD, Språkkode.NB, unntak1, unntak2);
     }
 
     @Test
@@ -79,7 +79,7 @@ class TekstformatererVedtaksbrevAllePermutasjonerAvFaktaTest {
         var unntak1 = Set.of(new HendelseMedUndertype(HendelseType.ES_FORELDREANSVAR_TYPE, HendelseUnderType.ES_IKKE_TILDELT), new HendelseMedUndertype(HendelseType.ES_FORELDREANSVAR_TYPE, HendelseUnderType.ES_ANDRE_FORELDRE_DODD));
         var unntak2 = Set.of(new HendelseMedUndertype(HendelseType.ES_ADOPSJONSVILKAARET_TYPE, HendelseUnderType.ES_BARN_OVER_15), new HendelseMedUndertype(HendelseType.ES_FORELDREANSVAR_TYPE, HendelseUnderType.ES_FORELDREANSVAR_BARN_OVER_15));
 
-        lagTeksterOgValider(FagsakYtelseType.ENGANGSTØNAD, Språkkode.nn, unntak1, unntak2);
+        lagTeksterOgValider(FagsakYtelseType.ENGANGSTØNAD, Språkkode.NN, unntak1, unntak2);
     }
 
     @SafeVarargs

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevIBiterTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevIBiterTest.java
@@ -240,7 +240,7 @@ class TekstformatererVedtaksbrevIBiterTest {
     @Test
     void skal_ha_riktig_tekst_for_særlige_grunner_når_det_er_reduksjon_av_beløp() {
         var felles = lagTestBuilder()
-                .medSpråkkode(Språkkode.nn)
+                .medSpråkkode(Språkkode.NN)
                 .medSak(HbSak.build()
                         .medYtelsetype(FagsakYtelseType.FORELDREPENGER)
                         .medErFødsel(true)

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevTest.java
@@ -61,7 +61,7 @@ class TekstformatererVedtaksbrevTest {
 
     @Test
     void skal_generere_vedtaksbrev_for_FP_og_tvillinger_og_simpel_uaktsomhet_nynorsk() throws Exception {
-        var data = getVedtaksbrevDataTvilling(FagsakYtelseType.FORELDREPENGER, HendelseType.FP_ANNET_HENDELSE_TYPE, Språkkode.nn);
+        var data = getVedtaksbrevDataTvilling(FagsakYtelseType.FORELDREPENGER, HendelseType.FP_ANNET_HENDELSE_TYPE, Språkkode.NN);
 
         var generertBrev = TekstformatererVedtaksbrev.lagVedtaksbrevFritekst(data);
         var fasit = les("/vedtaksbrev/FP_tvillinger_nn.txt");
@@ -98,7 +98,7 @@ class TekstformatererVedtaksbrevTest {
             .medKonfigurasjon(HbKonfigurasjon.builder()
                 .medKlagefristUker(6)
                 .build())
-            .medSpråkkode(språkkode != null ? språkkode : Språkkode.nb)
+            .medSpråkkode(språkkode != null ? språkkode : Språkkode.NB)
             .medVedtaksbrevType(VedtaksbrevType.ORDINÆR)
             .build();
         var perioder = List.of(
@@ -158,7 +158,7 @@ class TekstformatererVedtaksbrevTest {
             .medKonfigurasjon(HbKonfigurasjon.builder()
                 .medKlagefristUker(6)
                 .build())
-            .medSpråkkode(Språkkode.nb)
+            .medSpråkkode(Språkkode.NB)
             .medVedtaksbrevType(VedtaksbrevType.ORDINÆR)
             .build();
         var perioder = List.of(
@@ -346,7 +346,7 @@ class TekstformatererVedtaksbrevTest {
 
     @Test
     void skal_generere_vedtaksbrev_for_revurdering_med_SVP_og_tvillinger_og_simpel_uaktsomhet_nynorsk() throws Exception {
-        var data = getVedtaksbrevDataTvilling(FagsakYtelseType.SVANGERSKAPSPENGER, HendelseType.SVP_ANNET_TYPE, Språkkode.nn);
+        var data = getVedtaksbrevDataTvilling(FagsakYtelseType.SVANGERSKAPSPENGER, HendelseType.SVP_ANNET_TYPE, Språkkode.NN);
 
         var generertBrev = TekstformatererVedtaksbrev.lagVedtaksbrevFritekst(data);
         var fasit = les("/vedtaksbrev/SVP_tvillinger_nn.txt");
@@ -801,9 +801,9 @@ class TekstformatererVedtaksbrevTest {
 
     @Test
     void skal_generere_vedtaksbrev_overskrift_foreldrepenger_full_tilbakebetaling_nynorsk() {
-        var data = lagBrevOverskriftTestoppsett(FagsakYtelseType.FORELDREPENGER, VedtakResultatType.FULL_TILBAKEBETALING, Språkkode.nn);
+        var data = lagBrevOverskriftTestoppsett(FagsakYtelseType.FORELDREPENGER, VedtakResultatType.FULL_TILBAKEBETALING, Språkkode.NN);
 
-        var overskrift = TekstformatererVedtaksbrev.lagVedtaksbrevOverskrift(data, Språkkode.nn);
+        var overskrift = TekstformatererVedtaksbrev.lagVedtaksbrevOverskrift(data, Språkkode.NN);
         var fasit = "Du må betale tilbake foreldrepengane";
         assertThat(overskrift).isEqualToNormalizingNewlines(fasit);
     }
@@ -819,7 +819,7 @@ class TekstformatererVedtaksbrevTest {
 
     @Test
     void skal_generere_fritekst_og_uten_perioder_vedtaksbrev_for_FP_med_full_tilbakebetaling() throws IOException {
-        var fritekstVedtaksbrevData = lagFritekstVedtaksbrevData(FagsakYtelseType.FORELDREPENGER, VedtakResultatType.FULL_TILBAKEBETALING, Språkkode.nb);
+        var fritekstVedtaksbrevData = lagFritekstVedtaksbrevData(FagsakYtelseType.FORELDREPENGER, VedtakResultatType.FULL_TILBAKEBETALING, Språkkode.NB);
         var generertBrev = TekstformatererVedtaksbrev.lagVedtaksbrevFritekst(fritekstVedtaksbrevData);
         assertThat(generertBrev).isNotEmpty();
         var fasit = les("/vedtaksbrev/Fritekst_Vedtaksbrev_FP_full_tilbakebetaling.txt");
@@ -828,7 +828,7 @@ class TekstformatererVedtaksbrevTest {
 
     @Test
     void skal_generere_fritekst_og_uten_perioder_vedtaksbrev_for_ES_med_ingen_tilbakebetaling() throws IOException {
-        var fritekstVedtaksbrevData = lagFritekstVedtaksbrevData(FagsakYtelseType.ENGANGSTØNAD, VedtakResultatType.INGEN_TILBAKEBETALING, Språkkode.nb);
+        var fritekstVedtaksbrevData = lagFritekstVedtaksbrevData(FagsakYtelseType.ENGANGSTØNAD, VedtakResultatType.INGEN_TILBAKEBETALING, Språkkode.NB);
         var generertBrev = TekstformatererVedtaksbrev.lagVedtaksbrevFritekst(fritekstVedtaksbrevData);
         assertThat(generertBrev).isNotEmpty();
         var fasit = les("/vedtaksbrev/Fritekst_Vedtaksbrev_ES_ingen_tilbakebetaling.txt");
@@ -853,7 +853,7 @@ class TekstformatererVedtaksbrevTest {
                 .medAntallBarn(1)
                 .medDatoFagsakvedtak(LocalDate.now())
                 .build())
-            .medSpråkkode(språkkode != null ? språkkode : Språkkode.nb)
+            .medSpråkkode(språkkode != null ? språkkode : Språkkode.NB)
             .build();
         return new HbVedtaksbrevData(vedtaksbrevFelles, Collections.emptyList());
     }
@@ -984,7 +984,7 @@ Vedlegg: Resultatet av tilbakebetalingssaken""");
             .medKonfigurasjon(HbKonfigurasjon.builder()
                 .medKlagefristUker(6)
                 .build())
-            .medSpråkkode(Språkkode.nb)
+            .medSpråkkode(Språkkode.NB)
             .medVedtaksbrevType(VedtaksbrevType.ORDINÆR)
             .build();
         var perioder = List.of(
@@ -1039,7 +1039,7 @@ Vedlegg: Resultatet av tilbakebetalingssaken""");
                 .medOriginalBehandlingDatoFagsakvedtak(LocalDate.of(2020, 3, 4))
                 .build())
             .medLovhjemmelVedtak("Folketrygdloven § 22-15")
-            .medSpråkkode(språkkode != null ? språkkode : Språkkode.nb)
+            .medSpråkkode(språkkode != null ? språkkode : Språkkode.NB)
             .medFritekstOppsummering("sender fritekst vedtaksbrev")
             .medVedtaksbrevType(VedtaksbrevType.FRITEKST_FEILUTBETALING_BORTFALT)
             .build();

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevVedleggTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/TekstformatererVedtaksbrevVedleggTest.java
@@ -52,7 +52,7 @@ class TekstformatererVedtaksbrevVedleggTest {
 
     @Test
     void skal_generere_vedlegg_med_en_periode_uten_renter_nynorsk() throws Exception {
-        var data = getVedtaksbrevData(Språkkode.nn);
+        var data = getVedtaksbrevData(Språkkode.NN);
 
         var generertBrev = TekstformatererVedtaksbrev.lagVedtaksbrevVedleggHtml(data);
         var fasit = les("/vedtaksbrev/vedlegg/vedlegg_uten_renter_nn.txt");
@@ -61,7 +61,7 @@ class TekstformatererVedtaksbrevVedleggTest {
 
     @Test
     void skal_generere_vedlegg_med_en_periode_uten_skatt() throws Exception {
-        var data = getVedtaksbrevData(Språkkode.nb, 10000, 30001, 30001, 0, 0);
+        var data = getVedtaksbrevData(Språkkode.NB, 10000, 30001, 30001, 0, 0);
 
         var generertBrev = TekstformatererVedtaksbrev.lagVedtaksbrevVedleggHtml(data);
         var fasit = les("/vedtaksbrev/vedlegg/vedlegg_uten_skatt.txt");
@@ -91,7 +91,7 @@ class TekstformatererVedtaksbrevVedleggTest {
                         .medVarsletBeløp(BigDecimal.valueOf(varslet))
                         .medVarsletDato(LocalDate.of(2020, 4, 4))
                         .build())
-                .medSpråkkode(språkkode != null ? språkkode : Språkkode.nb)
+                .medSpråkkode(språkkode != null ? språkkode : Språkkode.NB)
                 .build();
         var perioder = List.of(
                 HbVedtaksbrevPeriode.builder()

--- a/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtakHjemmelTest.java
+++ b/integrasjontjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtakHjemmelTest.java
@@ -31,15 +31,15 @@ class VedtakHjemmelTest {
     void skal_gi_riktig_hjemmel_når_det_ikke_er_foreldelse_eller_renter() {
         var vurderingPerioder = aktsomhet(periode, Function.identity());
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("folketrygdloven § 22-15");
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nn, true)).isEqualTo("folketrygdlova § 22-15");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("folketrygdloven § 22-15");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NN, true)).isEqualTo("folketrygdlova § 22-15");
     }
 
     @Test
     void skal_gi_riktig_hjemmel_når_det_er_forsto_burde_forstått_og_forsett() {
         var vurderingPerioder = aktsomhet(periode, a -> a.medAktsomhet(Aktsomhet.FORSETT).medIleggRenter(false));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("folketrygdloven § 22-15");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("folketrygdloven § 22-15");
     }
 
     @Test
@@ -47,7 +47,7 @@ class VedtakHjemmelTest {
         var vurderingPerioder = aktsomhet(VilkårResultat.FEIL_OPPLYSNINGER_FRA_BRUKER,
                 periode, a -> a.medAktsomhet(Aktsomhet.FORSETT));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("folketrygdloven §§ 22-15 og 22-17 a");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("folketrygdloven §§ 22-15 og 22-17 a");
     }
 
     @Test
@@ -55,15 +55,15 @@ class VedtakHjemmelTest {
         var vurderingPerioder = aktsomhet(VilkårResultat.FEIL_OPPLYSNINGER_FRA_BRUKER,
                 periode, a -> a.medAktsomhet(Aktsomhet.FORSETT));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, false)).isEqualTo("folketrygdloven § 22-15");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, false)).isEqualTo("folketrygdloven § 22-15");
     }
 
     @Test
     void skal_gi_riktig_hjemmel_når_det_ikke_kreves_tilbake_pga_lavt_beløp() {
         var vurderingPerioder = aktsomhet(periode, a -> a.medTilbakekrevSmåBeløp(false));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("folketrygdloven § 22-15 sjette ledd");
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nn, true)).isEqualTo("folketrygdlova § 22-15 sjette ledd");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("folketrygdloven § 22-15 sjette ledd");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NN, true)).isEqualTo("folketrygdlova § 22-15 sjette ledd");
     }
 
     @Test
@@ -74,7 +74,7 @@ class VedtakHjemmelTest {
             return f;
         });
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, Collections.emptyList(), VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("foreldelsesloven §§ 2 og 3");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, Collections.emptyList(), VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("foreldelsesloven §§ 2 og 3");
     }
 
     @Test
@@ -86,7 +86,7 @@ class VedtakHjemmelTest {
         });
         var vurderingPerioder = aktsomhet(periode, a -> a.medAktsomhet(Aktsomhet.GROVT_UAKTSOM).medIleggRenter(false));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("folketrygdloven § 22-15 og foreldelsesloven §§ 2 og 3");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("folketrygdloven § 22-15 og foreldelsesloven §§ 2 og 3");
     }
 
     @Test
@@ -94,7 +94,7 @@ class VedtakHjemmelTest {
         var vurdertForeldelse = lagForeldelseperiode(periode, f -> f.medForeldelseVurderingType(ForeldelseVurderingType.IKKE_FORELDET));
         var vurderingPerioder = aktsomhet(periode, a -> a.medAktsomhet(Aktsomhet.GROVT_UAKTSOM).medIleggRenter(true));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("folketrygdloven §§ 22-15 og 22-17 a");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("folketrygdloven §§ 22-15 og 22-17 a");
     }
 
     @Test
@@ -107,7 +107,7 @@ class VedtakHjemmelTest {
         });
         var vurderingPerioder = aktsomhet(periode, a -> a.medAktsomhet(Aktsomhet.GROVT_UAKTSOM).medIleggRenter(false));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true)).isEqualTo("folketrygdloven § 22-15 og foreldelsesloven §§ 2, 3 og 10");
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true)).isEqualTo("folketrygdloven § 22-15 og foreldelsesloven §§ 2, 3 og 10");
     }
 
     @Test
@@ -120,7 +120,7 @@ class VedtakHjemmelTest {
         });
         var vurderingPerioder = aktsomhet(periode, a -> a.medAktsomhet(Aktsomhet.GROVT_UAKTSOM).medIleggRenter(true));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.nb, true))
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.FØRSTEGANGSVEDTAK, Språkkode.NB, true))
                 .isEqualTo("folketrygdloven §§ 22-15 og 22-17 a og foreldelsesloven §§ 2, 3 og 10");
     }
 
@@ -128,7 +128,7 @@ class VedtakHjemmelTest {
     void skal_gi_riktig_hjemmel_når_det_ikke_er_foreldelse_eller_renter_er_klage() {
         var vurderingPerioder = aktsomhet(periode, Function.identity());
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.ENDRET_TIL_UGUNST_FOR_BRUKER, Språkkode.nb, true))
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, null, vurderingPerioder, VedtakHjemmel.EffektForBruker.ENDRET_TIL_UGUNST_FOR_BRUKER, Språkkode.NB, true))
                 .isEqualTo("folketrygdloven § 22-15 og forvaltningsloven § 35 c)");
     }
 
@@ -142,7 +142,7 @@ class VedtakHjemmelTest {
         });
         var vurderingPerioder = aktsomhet(periode, a -> a.medAktsomhet(Aktsomhet.GROVT_UAKTSOM).medIleggRenter(true));
 
-        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.ENDRET_TIL_GUNST_FOR_BRUKER, Språkkode.nb, true))
+        assertThat(VedtakHjemmel.lagHjemmelstekst(VedtakResultatType.INGEN_TILBAKEBETALING, vurdertForeldelse, vurderingPerioder, VedtakHjemmel.EffektForBruker.ENDRET_TIL_GUNST_FOR_BRUKER, Språkkode.NB, true))
                 .isEqualTo("folketrygdloven §§ 22-15 og 22-17 a, foreldelsesloven §§ 2, 3 og 10 og forvaltningsloven § 35 a)");
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
@@ -310,7 +310,7 @@ class BehandlingRestTjenesteTest {
     }
 
     private Behandling mockBehandling() {
-        var sak = Fagsak.opprettNy(new Saksnummer(GYLDIG_SAKSNR), NavBruker.opprettNy(new AktørId(GYLDIG_AKTØR_ID), Språkkode.nb));
+        var sak = Fagsak.opprettNy(new Saksnummer(GYLDIG_SAKSNR), NavBruker.opprettNy(new AktørId(GYLDIG_AKTØR_ID), Språkkode.NB));
         sak.setId(10L);
         var behandling = Behandling.nyBehandlingFor(sak, BehandlingType.REVURDERING_TILBAKEKREVING).build();
         behandling.setId(20L);

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
@@ -54,7 +54,7 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 class AksjonspunktRestTjenesteTest {
 
     private static final Saksnummer SAKSNUMMER = new Saksnummer("12345");
-    private static final NavBruker NAV_BRUKER = NavBruker.opprettNy(new AktørId(12345L), Språkkode.nb);
+    private static final NavBruker NAV_BRUKER = NavBruker.opprettNy(new AktørId(12345L), Språkkode.NB);
 
     private final AksjonspunktApplikasjonTjeneste aksjonspunktTjenesteMock = mock(AksjonspunktApplikasjonTjeneste.class);
 

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/BehandlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/behandling/dto/BehandlingDtoTjenesteTest.java
@@ -419,7 +419,7 @@ class BehandlingDtoTjenesteTest {
     }
 
     private Behandling lagBehandling(BehandlingStegType behandlingStegType, BehandlingStatus behandlingStatus) {
-        var fagsakId = fagsakRepository.lagre(Fagsak.opprettNy(saksnummer, NavBruker.opprettNy(new AktørId(GYLDIG_AKTØR_ID), Språkkode.nb)));
+        var fagsakId = fagsakRepository.lagre(Fagsak.opprettNy(saksnummer, NavBruker.opprettNy(new AktørId(GYLDIG_AKTØR_ID), Språkkode.NB)));
         var fagsak = fagsakRepository.finnEksaktFagsak(fagsakId);
         var behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.TILBAKEKREVING).build();
         behandling.setAnsvarligSaksbehandler("Z991136");

--- a/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/fordeling/FordelRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/fordeling/FordelRestTjenesteTest.java
@@ -102,7 +102,7 @@ class FordelRestTjenesteTest {
     }
 
     private Behandling lagBehandling() {
-        NavBruker navBruker = NavBruker.opprettNy(AKTØR_ID, Språkkode.nb);
+        NavBruker navBruker = NavBruker.opprettNy(AKTØR_ID, Språkkode.NB);
         Fagsak fagsak = Fagsak.opprettNy(SAKSNUMMER, navBruker);
         repositoryProvider.getFagsakRepository().lagre(fagsak);
         Behandling behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.TILBAKEKREVING).build();


### PR DESCRIPTION
Ekstra:
- Refererer til Frister direkte og ikke gjennom AutomatiskSaksbehandlingRepository
- Bytter Språkkode enum til å bruke store bokstaver. 