### PR TITLE
Publish k9 tilbake typescript client

### DIFF
--- a/.github/.m2/settings.xml
+++ b/.github/.m2/settings.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <activeProfiles>
+        <activeProfile>github</activeProfile>
+    </activeProfiles>
+
+    <profiles>
+        <profile>
+            <id>github</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>github</id>
+                    <name>GitHub Apache Maven Packages</name>
+                    <url>https://maven.pkg.github.com/navikt/fp-felles/</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <servers>
+        <server>
+            <id>github</id>
+            <username>x-access-token</username>
+            <password>${env.GH_ACCESS_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/.github/actions/generate-typescript-client/README.md
+++ b/.github/actions/generate-typescript-client/README.md
@@ -1,0 +1,10 @@
+actions/generate-typescript-client
+==================================
+
+Dette er ein custom composite action som genererer ny typescript klient kode ut frå openapi json.
+
+### Inputs
+
+- _openapiVersion_: Resultat frå generate-openapi action
+- _patchVersion_: Settast til build-version resultat frå build-app workflow.
+

--- a/.github/actions/generate-typescript-client/action.yaml
+++ b/.github/actions/generate-typescript-client/action.yaml
@@ -1,0 +1,31 @@
+name: Generate typescript client
+description: Generate typescript client from openapi spec.
+inputs:
+  openapiVersion:
+    description: The openapi version extracted from openapi.json
+    required: true
+  patchVersion:
+    description: 'The <TIMESTAMP>-<SHA> value used as a tag of the version for deployment.'
+    required: true
+outputs:
+  resultDir:
+    description: Directory in which the generated typescript client package was written
+    value: ${{ steps.set-output.outputs.resultDir }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set resultDir
+      id: set-output
+      shell: bash
+      run: echo "resultDir=web/target/ts-client/k9" >> $GITHUB_OUTPUT
+    - name: Typescript generate
+      id: typescript-generate
+      uses: navikt/openapi-ts-clientmaker@v2
+      with:
+        openapi-spec-file: web/src/main/resources/openapi-ts-client/k9/k9-tilbake.openapi.json
+        package-json-file: web/src/main/resources/openapi-ts-client/k9/package.json
+        package-json-version: "${{ env.PACKAGE_JSON_VERSION }}"
+        out-dir: "${{ steps.set-output.outputs.resultDir }}"
+      env:
+        PACKAGE_JSON_VERSION: "${{ inputs.openapiVersion }}.${{ inputs.patchVersion }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,44 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
     secrets: inherit
 
+  typescript-client:
+    name: Build typescript client
+    runs-on: ubuntu-latest
+    needs: build-app
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        # TODO: Bruk main versjon når denne er testa og merged:
+      - uses: navikt/sif-gha-workflows/.github/actions/maven/generate-openapi@generate-openapi-dontCommit
+        id: generate-openapi
+        with:
+          readerToken: ${{ secrets.READER_TOKEN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          openapiFileName: k9/k9-tilbake.openapi.json
+          dontCommit: 'true'
+      - uses: ./.github/actions/generate-typescript-client
+        id: generate-typescript
+        with:
+          openapiVersion: ${{ steps.generate-openapi.outputs.openapiVersion }}
+          patchVersion: ${{ needs.build-app.outputs.build-version }}
+      # XXX Her kunne vi også gjere kompileringssjekk med k9-sak-web, slik vi gjere for k9-sak, k9-klage, etc.
+      # check if built typescript client has changed from last published
+      - uses: navikt/openapi-ts-clientmaker/extra/actions/compare-with-published@v2
+        id: compare-with-published
+        with:
+          localPath: "${{ steps.generate-typescript.outputs.resultDir }}"
+          npmPackageName: k9-tilbake-typescript-client
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      # if changed, publish
+      - uses: navikt/openapi-ts-clientmaker/extra/actions/publish-typescript-client@v2
+        if: |
+          github.ref_name == github.event.repository.default_branch &&
+          steps.compare-with-published.outputs.changed == 'true'
+        with:
+          contentPath: "${{ steps.generate-typescript.outputs.resultDir }}"
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
   publish-image-k9:
     # målet her er at k9-verdikjede skal kunne hente imaget for k9-tilbake
     # enkleste vei ser ut til å bygge på nytt og puhse til k9sakbehandling i GAR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
     needs: build-app
     permissions:
       contents: read
+      packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: navikt/fp-gha-workflows/.github/actions/setup-java-and-maven@main
@@ -42,7 +44,7 @@ jobs:
           github-token: ${{ secrets.READER_TOKEN }}
       - uses: navikt/fp-gha-workflows/.github/actions/build-maven-application@main
         with:
-          skip-tests: 'true'
+          skip-tests: true
       - name: Openapi generate
         shell: bash
         run: mvn exec:java --projects web

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           skip-tests: true
       - name: Openapi generate
         shell: bash
-        run: mvn exec:java --projects web
+        run: mvn -s settings.xml -q -e -B exec:java --projects web
       - name: Openapi version
         id: openapi-version
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    env:
+      OPENAPI_FILE: k9/k9-tilbake.openapi.json
     steps:
       - uses: actions/checkout@v4
       - uses: navikt/fp-gha-workflows/.github/actions/setup-java-and-maven@main
@@ -53,7 +55,7 @@ jobs:
         shell: bash
         # extract version number from generated openapi.json
         run: |
-          echo "openapiVersion=$(jq --exit-status --raw-output '.info.version | capture("^(?<major>\\d+)\\.(?<minor>\\d+)$") | .major + "." + .minor' ./web/src/main/resources/openapi-ts-client/${{ inputs.openapiFileName }} || echo 'FEIL')" >> $GITHUB_OUTPUT
+          echo "openapiVersion=$(jq --exit-status --raw-output '.info.version | capture("^(?<major>\\d+)\\.(?<minor>\\d+)$") | .major + "." + .minor' ./web/src/main/resources/openapi-ts-client/${{ env.OPENAPI_FILE }} || echo 'FEIL')" >> $GITHUB_OUTPUT
       - name: Feilsjekk OPENAPI_VERSION
         if: "${{ env.OPENAPI_VERSION == 'FEIL'}}"
         env:
@@ -61,7 +63,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.setFailed('fant ikkje korrekt openapi version frå ${{ inputs.openapiFileName }}')
+            core.setFailed('fant ikkje korrekt openapi version frå ${{ env.OPENAPI_FILE }}')
 
       - uses: ./.github/actions/generate-typescript-client
         id: generate-typescript

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,18 +37,34 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        # TODO: Bruk main versjon når denne er testa og merged:
-      - uses: navikt/sif-gha-workflows/.github/actions/maven/generate-openapi@generate-openapi-dontCommit
-        id: generate-openapi
+      - uses: navikt/fp-gha-workflows/.github/actions/setup-java-and-maven@main
         with:
-          readerToken: ${{ secrets.READER_TOKEN }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          openapiFileName: k9/k9-tilbake.openapi.json
-          dontCommit: 'true'
+          github-token: ${{ secrets.READER_TOKEN }}
+      - uses: navikt/fp-gha-workflows/.github/actions/build-maven-application@main
+        with:
+          skip-tests: 'true'
+      - name: Openapi generate
+        shell: bash
+        run: mvn exec:java --projects web
+      - name: Openapi version
+        id: openapi-version
+        shell: bash
+        # extract version number from generated openapi.json
+        run: |
+          echo "openapiVersion=$(jq --exit-status --raw-output '.info.version | capture("^(?<major>\\d+)\\.(?<minor>\\d+)$") | .major + "." + .minor' ./web/src/main/resources/openapi-ts-client/${{ inputs.openapiFileName }} || echo 'FEIL')" >> $GITHUB_OUTPUT
+      - name: Feilsjekk OPENAPI_VERSION
+        if: "${{ env.OPENAPI_VERSION == 'FEIL'}}"
+        env:
+          OPENAPI_VERSION: "${{ steps.openapi-version.outputs.openapiVersion }}"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed('fant ikkje korrekt openapi version frå ${{ inputs.openapiFileName }}')
+
       - uses: ./.github/actions/generate-typescript-client
         id: generate-typescript
         with:
-          openapiVersion: ${{ steps.generate-openapi.outputs.openapiVersion }}
+          openapiVersion: ${{ steps.openapi-version.outputs.openapiVersion }}
           patchVersion: ${{ needs.build-app.outputs.build-version }}
       # XXX Her kunne vi også gjere kompileringssjekk med k9-sak-web, slik vi gjere for k9-sak, k9-klage, etc.
       # check if built typescript client has changed from last published

--- a/.run/web_generate k9-tilbake typescript client.run.xml
+++ b/.run/web_generate k9-tilbake typescript client.run.xml
@@ -2,8 +2,8 @@
   <configuration default="false" name="web/generate k9-tilbake typescript client" type="docker-deploy" factoryName="docker-image" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="imageTag" value="europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v1" />
-        <option name="command" value="-- --openapi-spec-file in/k9-tilbake.openapi.json --package-json-file in/package.json --client-name K9TilbakeClient" />
+        <option name="imageTag" value="europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v2" />
+        <option name="command" value="-- --openapi-spec-file in/k9-tilbake.openapi.json --package-json-file in/package.json" />
         <option name="containerName" value="openapi-ts-clientmaker-cli" />
         <option name="volumeBindings">
           <list>

--- a/.run/web_generate k9-tilbake.openapi.json.run.xml
+++ b/.run/web_generate k9-tilbake.openapi.json.run.xml
@@ -84,7 +84,6 @@
     <option name="MAIN_CLASS_NAME" value="no.nav.foreldrepenger.tilbakekreving.web.app.util.OpenapiGenerate" />
     <module name="webapp" />
     <option name="PROGRAM_PARAMETERS" value="src/main/resources/openapi-ts-client/k9/k9-tilbake.openapi.json" />
-    <option name="VM_PARAMETERS" value="-Dapp.name=k9-tilbake" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/web" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/web_pull openapi-ts-clientmaker-cli.run.xml
+++ b/.run/web_pull openapi-ts-clientmaker-cli.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="web/pull openapi-ts-clientmaker-cli" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="docker container rm openapi-ts-clientmaker-cli; docker pull europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v1" />
+    <option name="SCRIPT_TEXT" value="docker container rm openapi-ts-clientmaker-cli; docker pull europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v2" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -91,6 +91,12 @@
                 <configuration>
                     <mainClass>no.nav.foreldrepenger.tilbakekreving.web.app.util.OpenapiGenerate</mainClass>
                     <classpathScope>compile</classpathScope>
+                    <systemProperties>
+                        <systemProperty>
+                            <key>app.name</key>
+                            <value>k9-tilbake</value>
+                        </systemProperty>
+                    </systemProperties>
                     <arguments>
                         <argument>${project.build.sourceDirectory}/../resources/openapi-ts-client/k9/k9-tilbake.openapi.json</argument>
                     </arguments>


### PR DESCRIPTION
## Bakgrunn

Ønske om å generere typescript klientkode for kommunikasjon med k9-tilbake server frå k9-sak-web frontend.

## Løysing

Legger inn ny jobb i github workflow. Denne bygger og publiserer typescript klient pakke i github registry, slik at frontend kan bruke denne som dependency. Publisering skjer kun når bygg skjer på master branch.