### PR TITLE
Oppgrader openapi-spec-utils til versjon 2.

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- versjon brukes fra webapp-modulen under resources/web.swagger/index.html og må være samme som faktisk avhengighet som brukes -->
         <swagger-ui.version>5.27.0</swagger-ui.version>
-        <openapi-spec-utils.version>1.5.0</openapi-spec-utils.version>
+        <openapi-spec-utils.version>2.0.0</openapi-spec-utils.version>
     </properties>
 
     <build>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- versjon brukes fra webapp-modulen under resources/web.swagger/index.html og må være samme som faktisk avhengighet som brukes -->
         <swagger-ui.version>5.27.0</swagger-ui.version>
-        <openapi-spec-utils.version>2.0.0</openapi-spec-utils.version>
+        <openapi-spec-utils.version>2.0.1</openapi-spec-utils.version>
     </properties>
 
     <build>

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/jackson/ObjectMapperFactory.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/jackson/ObjectMapperFactory.java
@@ -55,7 +55,7 @@ public class ObjectMapperFactory {
     /**
      * Scan subtyper dynamisk fra WAR slik at superklasse slipper å deklarere @JsonSubtypes.
      */
-    private static List<Class<?>> getJsonTypeNameClasses() {
+    public static List<Class<?>> getJsonTypeNameClasses() {
         Class<ObjectMapperFactory> cls = ObjectMapperFactory.class;
         IndexClasses indexClasses;
         try {

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/konfig/ApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/konfig/ApiConfig.java
@@ -9,7 +9,10 @@ import java.util.Set;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
+import no.nav.foreldrepenger.tilbakekreving.web.app.jackson.ObjectMapperFactory;
 import no.nav.openapi.spec.utils.http.DynamicObjectMapperResolverVaryFilter;
+
+import no.nav.openapi.spec.utils.openapi.PrefixStrippingFQNTypeNameResolver;
 
 import org.glassfish.jersey.server.ServerProperties;
 
@@ -72,13 +75,15 @@ public class ApiConfig extends Application {
     private OpenAPI resolveOpenAPI() {
         final var info = new Info()
             .title("Vedtaksløsningen - Tilbakekreving")
-            .version("1.0")
+            .version("1.1")
             .description("REST grensesnitt for tilbakekreving.");
         final var server = new Server().url(JettyServer.getContextPath());
         final var openapiSetupHelper = new OpenApiSetupHelper(this, info, server);
         for(final var cls : getClasses()) {
             openapiSetupHelper.addResourceClass(cls.getName());
         }
+        openapiSetupHelper.registerSubTypes(ObjectMapperFactory.getJsonTypeNameClasses());
+        openapiSetupHelper.setTypeNameResolver(new PrefixStrippingFQNTypeNameResolver("no.nav.foreldrepenger.", "no.nav."));
         try {
             return openapiSetupHelper.resolveOpenAPI();
         } catch (OpenApiConfigurationException e) {


### PR DESCRIPTION
Dette medfører betydleg endring i generert openapi spesifikasjon. Versjonsnr aukast derfor til 1.1

Alle typenamn i openapi spesifikasjonen blir no generert med pakkenamn, så ein unngår kollisjoner når typer frå ulike pakker har samme basenamn. Det gjere det og enklare å sjå kvar i serverkjeldekode ein dto type eller enum kjem frå.

Med pakkenamn i typenamnet treng ein ikkje lenger spesialfunksjon for å namngje enum typer basert på property namnet dei er brukt i, sidan ein unngår namnekollisjoner også for disse. Dette gjere det lettare å sjå den direkte koblinga mellom enums i generert openapi spesifikasjon og java kjeldekoden.

For å unngå unødvendig lange typenamn bruker vi ein stripper som fjerner "no.nav.", eller "no.nav.foreldrepenger." viss pakkenamnet starter med dette.

Denne versjonen innfører også støtte for "automatiske subtyper". Generert openapi spesifikasjon vil altså automatisk innehalde union type for alle subtyper som er registrert inn med "registerSubTypes" metoden. Dette i motsetning til tidlegare då berre den øverste felles supertypen vart med i spesifikasjonen, så lenge ein ikkje hadde annotert spesifikt med subtype på endepunktet eller dto typen.

Denne endring skal ikkje ha nokon praktisk betydning for anna enn generering av typescript klient kode. Swagger server brukergrensesnitt fungerer som før.