### PR TITLE
openapi: Fjerner ikkje "foreldrepenger." prefiks frå genererte typer lenger

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/konfig/ApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/konfig/ApiConfig.java
@@ -83,7 +83,7 @@ public class ApiConfig extends Application {
             openapiSetupHelper.addResourceClass(cls.getName());
         }
         openapiSetupHelper.registerSubTypes(ObjectMapperFactory.getJsonTypeNameClasses());
-        openapiSetupHelper.setTypeNameResolver(new PrefixStrippingFQNTypeNameResolver("no.nav.foreldrepenger.", "no.nav."));
+        openapiSetupHelper.setTypeNameResolver(new PrefixStrippingFQNTypeNameResolver("no.nav."));
         try {
             return openapiSetupHelper.resolveOpenAPI();
         } catch (OpenApiConfigurationException e) {


### PR DESCRIPTION
For å vere meir konsistent, og gjere det lettare å sjå kva backend typenamn kjem frå.

Skal ikkje ha nokon påvirkning på noko sidan ingen kode har tatt i bruk kode generert ut frå denne endå.