### PR TITLE
TFP-6395 forberede one-shot-kall til fpsak

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/FellesTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/FellesTask.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.BehandlingType;
@@ -31,8 +30,8 @@ public abstract class FellesTask {
         return fagsystemKlient.finnesBehandlingIFagsystem(saksnummer, henvisning);
     }
 
-    protected List<EksternBehandlingsinfoDto> hentBehandlingerFraFagsystem(String saksnummer) {
-        return fagsystemKlient.hentBehandlingForSaksnummer(saksnummer);
+    protected Optional<EksternBehandlingsinfoDto> hentBehandlingerFraFagsystem(String saksnummer, Henvisning henvisning) {
+        return fagsystemKlient.hentBehandlingForSaksnummerHenvisning(saksnummer, henvisning);
     }
 
     protected List<Behandling> hentBehandlingerForSaksnummer(String saksnummer) {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/batch/HåndterGamleKravgrunnlagTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/batch/HåndterGamleKravgrunnlagTjeneste.java
@@ -7,12 +7,6 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.ManglendeKravgrunnlagException;
-
-import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.SperringKravgrunnlagException;
-
-import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.UkjentKvitteringFraOSException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,6 +14,9 @@ import no.nav.foreldrepenger.kontrakter.fpwsproxy.tilbakekreving.kravgrunnlag.re
 import no.nav.foreldrepenger.kontrakter.fpwsproxy.tilbakekreving.kravgrunnlag.request.KodeAksjon;
 import no.nav.foreldrepenger.tilbakekreving.behandling.impl.BehandlingTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.KravgrunnlagHenter;
+import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.ManglendeKravgrunnlagException;
+import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.SperringKravgrunnlagException;
+import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.UkjentKvitteringFraOSException;
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.førstegang.KravgrunnlagMapper;
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.førstegang.KravgrunnlagXmlUnmarshaller;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
@@ -172,14 +169,12 @@ public class HåndterGamleKravgrunnlagTjeneste {
     }
 
     private Optional<EksternBehandlingsinfoDto> hentYtelsebehandlingFraFagsaksystemet(String saksnummer, Henvisning henvisning) {
-        List<EksternBehandlingsinfoDto> eksternBehandlinger = fagsystemKlient.hentBehandlingForSaksnummer(saksnummer);
-        if (!eksternBehandlinger.isEmpty()) {
-            return eksternBehandlinger.stream()
-                    .filter(eksternBehandlingsinfoDto -> eksternBehandlingsinfoDto.getHenvisning().equals(henvisning)).findAny();
+        var eksternBehandlinger = fagsystemKlient.hentBehandlingForSaksnummerHenvisning(saksnummer, henvisning);
+        if (eksternBehandlinger.isEmpty()) {
+            //FIXME k9-tilbake Må tilpasse for å støtte også k9
+            LOG.warn("Saksnummer={} finnes ikke i fpsak", saksnummer);
         }
-        //FIXME k9-tilbake Må tilpasse for å støtte også k9
-        LOG.warn("Saksnummer={} finnes ikke i fpsak", saksnummer);
-        return Optional.empty();
+        return eksternBehandlinger;
     }
 
     private void oppdaterMedHenvisningOgSaksnummer(Long mottattXmlId, Henvisning henvisning, String saksnummer) {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/førstegang/LesKravgrunnlagTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/førstegang/LesKravgrunnlagTask.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.førstegang;
 
-import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -121,9 +120,7 @@ public class LesKravgrunnlagTask extends FellesTask implements ProsessTaskHandle
     }
 
     private void oppdaterHenvisningFraGrunnlag(Behandling behandling, String saksnummer, Henvisning grunnlagHenvisning) {
-        List<EksternBehandlingsinfoDto> eksternBehandlinger = hentBehandlingerFraFagsystem(saksnummer);
-        Optional<EksternBehandlingsinfoDto> eksternBehandlingsinfoDto = eksternBehandlinger.stream()
-                .filter(eksternBehandling -> grunnlagHenvisning.equals(eksternBehandling.getHenvisning())).findFirst();
+        var eksternBehandlingsinfoDto = hentBehandlingerFraFagsystem(saksnummer, grunnlagHenvisning);
         if (eksternBehandlingsinfoDto.isPresent()) {
             LOG.info("Oppdaterer EksternBehandling henvisning={} for behandlingId={}", grunnlagHenvisning, behandling.getId());
             EksternBehandlingsinfoDto eksternBehandlingDto = eksternBehandlingsinfoDto.get();

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/revurdering/HentKravgrunnlagTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/revurdering/HentKravgrunnlagTask.java
@@ -1,8 +1,6 @@
 package no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.revurdering;
 
 import java.math.BigInteger;
-import java.util.List;
-import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -101,9 +99,7 @@ public class HentKravgrunnlagTask implements ProsessTaskHandler {
     }
 
     private void oppdaterHenvisningFraGrunnlag(Behandling behandling, String saksnummer, Henvisning grunnlagHenvisning) {
-        List<EksternBehandlingsinfoDto> eksternBehandlinger = hentBehandlingerFraFagsystem(saksnummer);
-        Optional<EksternBehandlingsinfoDto> eksternBehandlingsinfoDto = eksternBehandlinger.stream()
-                .filter(eksternBehandling -> grunnlagHenvisning.equals(eksternBehandling.getHenvisning())).findFirst();
+        var eksternBehandlingsinfoDto = fagsystemKlient.hentBehandlingForSaksnummerHenvisning(saksnummer, grunnlagHenvisning);
         if (eksternBehandlingsinfoDto.isPresent()) {
             LOG.info("Oppdaterer EksternBehandling henvisning={} for behandlingId={}", grunnlagHenvisning, behandling.getId());
             EksternBehandlingsinfoDto eksternBehandlingDto = eksternBehandlingsinfoDto.get();
@@ -113,10 +109,6 @@ public class HentKravgrunnlagTask implements ProsessTaskHandler {
             throw new TekniskException("FPT-587169",
                     String.format("Hentet et tilbakekrevingsgrunnlag fra Økonomi for en behandling som ikke finnes i Fagsaksystemet for saksnummer=%s, henvisning=%s. Kravgrunnlaget skulle kanskje til et annet system. Si i fra til Økonomi!", saksnummer, grunnlagHenvisning));
         }
-    }
-
-    private List<EksternBehandlingsinfoDto> hentBehandlingerFraFagsystem(String saksnummer) {
-        return fagsystemKlient.hentBehandlingForSaksnummer(saksnummer);
     }
 
     private void lagHistorikkInnslagForMotattKravgrunnlag(Behandling behandling, Kravgrunnlag431 kravgrunnlag431) {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/batch/HåndterGamleKravgrunnlagTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/batch/HåndterGamleKravgrunnlagTaskTest.java
@@ -12,8 +12,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -126,7 +124,7 @@ class HåndterGamleKravgrunnlagTaskTest {
         when(økonomiProxyKlient.hentKravgrunnlag(any(HentKravgrunnlagDetaljDto.class))).thenReturn(lagKravgrunnlag(true, ENHET, true));
         var eksternBehandlingsinfoDto = lagEksternBehandlingData();
 
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer(anyString())).thenReturn(List.of(eksternBehandlingsinfoDto));
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(anyString(), any())).thenReturn(Optional.of(eksternBehandlingsinfoDto));
         when(fagsystemKlientMock.hentBehandlingsinfo(any(UUID.class), any(Tillegsinformasjon.class), any(Tillegsinformasjon.class))).thenReturn(lagSamletEksternBehandlingData(eksternBehandlingsinfoDto));
         when(fagsystemKlientMock.hentBehandlingsinfo(any(UUID.class), any(Tillegsinformasjon.class))).thenReturn(lagSamletEksternBehandlingData(eksternBehandlingsinfoDto));
         when(fagsystemKlientMock.hentBehandlingOptional(any(UUID.class))).thenReturn(Optional.of(eksternBehandlingsinfoDto));
@@ -189,7 +187,7 @@ class HåndterGamleKravgrunnlagTaskTest {
 
     @Test
     void skal_kjøre_tasken_for_å_prosessere_gammel_kravgrunnlag_når_eksternBehandling_ikke_finnes_i_fpsak() {
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer(anyString())).thenReturn(new ArrayList<>());
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(anyString(), any())).thenReturn(Optional.empty());
         håndterGamleKravgrunnlagTask.doTask(lagProsessTaskData());
         assertThat(mottattXmlRepository.finnArkivertMottattXml(mottattXmlId)).isNotNull();
         assertThat(mottattXmlRepository.finnMottattXml(mottattXmlId)).isNull();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/finn/FinnGrunnlagTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/finn/FinnGrunnlagTaskTest.java
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import no.nav.foreldrepenger.tilbakekreving.dokumentbestilling.felles.pdf.BrevSporingTjeneste;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -30,6 +28,7 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandli
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.ekstern.EksternBehandling;
+import no.nav.foreldrepenger.tilbakekreving.dokumentbestilling.felles.pdf.BrevSporingTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.Henvisning;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingsinfoDto;
 import no.nav.foreldrepenger.tilbakekreving.grunnlag.KravVedtakStatusRepository;
@@ -211,7 +210,7 @@ class FinnGrunnlagTaskTest extends FellesTestOppsett {
         EksternBehandlingsinfoDto førsteVedtak = new EksternBehandlingsinfoDto();
         førsteVedtak.setHenvisning(HENVISNING);
         førsteVedtak.setUuid(FPSAK_BEHANDLING_UUID);
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer(saksnummer)).thenReturn(List.of(førsteVedtak));
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(saksnummer, HENVISNING)).thenReturn(Optional.of(førsteVedtak));
 
         Long mottattXmlId = mottattXmlRepository.lagreMottattXml(getInputXML("xml/kravgrunnlag_periode_YTEL_ENDR_samme_referanse.xml"));
         mottattXmlRepository.oppdaterMedHenvisningOgSaksnummer(ANNEN_HENVISNING, saksnummer, mottattXmlId);
@@ -313,6 +312,7 @@ class FinnGrunnlagTaskTest extends FellesTestOppsett {
         mottattXmlId = mottattXmlRepository.lagreMottattXml(getInputXML("xml/kravvedtakstatus_ENDR.xml"));
         mottattXmlRepository.oppdaterMedHenvisningOgSaksnummer(ANNEN_HENVISNING, saksnummer, mottattXmlId);
 
+        mockFagsystemKlientRespons();
         ProsessTaskData prosessTaskData = opprettFinngrunnlagProsessTask();
         finnGrunnlagTask.doTask(prosessTaskData);
 
@@ -339,15 +339,11 @@ class FinnGrunnlagTaskTest extends FellesTestOppsett {
     }
 
     private void mockFagsystemKlientRespons() {
-        EksternBehandlingsinfoDto førsteVedtak = new EksternBehandlingsinfoDto();
-        førsteVedtak.setHenvisning(HENVISNING);
-        førsteVedtak.setUuid(FPSAK_BEHANDLING_UUID);
+        EksternBehandlingsinfoDto vedtak = new EksternBehandlingsinfoDto();
+        vedtak.setHenvisning(FinnGrunnlagTaskTest.ANNEN_HENVISNING);
+        vedtak.setUuid(UUID.randomUUID());
 
-        EksternBehandlingsinfoDto andreVedtak = new EksternBehandlingsinfoDto();
-        førsteVedtak.setHenvisning(ANNEN_HENVISNING);
-        andreVedtak.setUuid(UUID.randomUUID());
-
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer(saksnummer)).thenReturn(List.of(førsteVedtak, andreVedtak));
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(saksnummer, FinnGrunnlagTaskTest.ANNEN_HENVISNING)).thenReturn(Optional.of(vedtak));
     }
 
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/førstegang/LesKravgrunnlagTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/førstegang/LesKravgrunnlagTaskTest.java
@@ -6,10 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -50,7 +49,7 @@ class LesKravgrunnlagTaskTest extends FellesTestOppsett {
 
     @Test
     void skal_utføre_leskravgrunnlag_task_forGyldigBehandling() {
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer(saksnummer)).thenReturn(lagResponsFraFagsystemKlient());
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(eq(saksnummer), any())).thenReturn(lagResponsFraFagsystemKlient());
         lesKravgrunnlagTask.doTask(lagProsessTaskData());
 
         assertTrue(grunnlagRepository.harGrunnlagForBehandlingId(behandling.getId()));
@@ -61,7 +60,7 @@ class LesKravgrunnlagTaskTest extends FellesTestOppsett {
 
     @Test
     void skal_ikke_utføre_leskravgrunnlag_task_når_grunnlag_referanse_ikke_finnes_i_fagsystem() {
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer(saksnummer)).thenReturn(Collections.emptyList());
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(eq(saksnummer), any())).thenReturn(Optional.empty());
 
         var e = assertThrows(TekniskException.class, () -> lesKravgrunnlagTask.doTask(lagProsessTaskData()));
         assertThat(e.getMessage()).contains("FPT-587195");
@@ -87,7 +86,7 @@ class LesKravgrunnlagTaskTest extends FellesTestOppsett {
 
     @Test
     void skal_utføre_les_kravgrunnlag_task_for_ugyldig_kravgrunnlag() {
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer(saksnummer)).thenReturn(lagResponsFraFagsystemKlient());
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(eq(saksnummer), any())).thenReturn(lagResponsFraFagsystemKlient());
         kravgrunnlagId = mottattXmlRepository.lagreMottattXml(getInputXML("xml/kravgrunnlag_periode_ugyldig_ENDR_negativ_beløp.xml"));
         lesKravgrunnlagTask.doTask(lagProsessTaskData());
         assertTilkobling();
@@ -104,11 +103,11 @@ class LesKravgrunnlagTaskTest extends FellesTestOppsett {
         return behandling;
     }
 
-    private List<EksternBehandlingsinfoDto> lagResponsFraFagsystemKlient() {
+    private Optional<EksternBehandlingsinfoDto> lagResponsFraFagsystemKlient() {
         EksternBehandlingsinfoDto eksternBehandlingsinfoDto = new EksternBehandlingsinfoDto();
         eksternBehandlingsinfoDto.setUuid(UUID.randomUUID());
         eksternBehandlingsinfoDto.setHenvisning(Henvisning.fraEksternBehandlingId(REFERANSE));
-        return List.of(eksternBehandlingsinfoDto);
+        return Optional.of(eksternBehandlingsinfoDto);
     }
 
     private ProsessTaskData lagProsessTaskData() {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/status/LesKravvedtakStatusTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/hentgrunnlag/status/LesKravvedtakStatusTaskTest.java
@@ -5,14 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import no.nav.foreldrepenger.tilbakekreving.dokumentbestilling.felles.pdf.BrevSporingTjeneste;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +36,7 @@ import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.reposito
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.geografisk.Språkkode;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.testutilities.kodeverk.TestFagsakUtil;
+import no.nav.foreldrepenger.tilbakekreving.dokumentbestilling.felles.pdf.BrevSporingTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.Henvisning;
 import no.nav.foreldrepenger.tilbakekreving.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.EksternBehandlingsinfoDto;
@@ -79,7 +79,7 @@ class LesKravvedtakStatusTaskTest extends FellesTestOppsett {
         behandling = lagBehandling();
         lagEksternBehandling(behandling);
         InternalManipulerBehandling.forceOppdaterBehandlingSteg(behandling, BehandlingStegType.TBKGSTEG);
-        when(fagsystemKlientMock.hentBehandlingForSaksnummer("139015144")).thenReturn(lagResponsFraFagsystemKlient());
+        when(fagsystemKlientMock.hentBehandlingForSaksnummerHenvisning(eq("139015144"), any())).thenReturn(lagResponsFraFagsystemKlient());
 
         mottattXmlId = mottattXmlRepository.lagreMottattXml(getInputXML("xml/kravgrunnlag_periode_FEIL_samme_referanse.xml"));
         lesKravgrunnlagTask.doTask(lagProsessTaskData(mottattXmlId, LES_KRAV_GRUNNLAG_TASK));
@@ -299,10 +299,10 @@ class LesKravvedtakStatusTaskTest extends FellesTestOppsett {
         eksternBehandlingRepository.lagre(eksternBehandling);
     }
 
-    private List<EksternBehandlingsinfoDto> lagResponsFraFagsystemKlient() {
+    private Optional<EksternBehandlingsinfoDto> lagResponsFraFagsystemKlient() {
         var eksternBehandlingsinfoDto = new EksternBehandlingsinfoDto();
         eksternBehandlingsinfoDto.setUuid(UUID.randomUUID());
         eksternBehandlingsinfoDto.setHenvisning(Henvisning.fraEksternBehandlingId(REFERANSE));
-        return List.of(eksternBehandlingsinfoDto);
+        return Optional.of(eksternBehandlingsinfoDto);
     }
 }

--- a/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtaksbrevTjeneste.java
+++ b/integrasjontjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/tilbakekreving/dokumentbestilling/vedtak/VedtaksbrevTjeneste.java
@@ -97,7 +97,6 @@ import no.nav.foreldrepenger.tilbakekreving.dokumentbestilling.vedtak.handlebars
 import no.nav.foreldrepenger.tilbakekreving.dokumentbestilling.vedtak.handlebars.dto.periode.HbVurderinger;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.Tillegsinformasjon;
 import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SamletEksternBehandlingInfo;
-import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.SøknadType;
 import no.nav.foreldrepenger.tilbakekreving.felles.Periode;
 
 
@@ -348,8 +347,8 @@ public class VedtaksbrevTjeneste {
                 .medAntallBarn(fagsystemBehandling.getAntallBarnSøktFor());
         if (trengerSkilleFødselOgAdopsjon(behandling)) {
             hbSakBuilder
-                    .medErFødsel(SøknadType.FØDSEL == fagsystemBehandling.getSøknadType())
-                    .medErAdopsjon(SøknadType.ADOPSJON == fagsystemBehandling.getSøknadType());
+                    .medErFødsel(fagsystemBehandling.gjelderFødsel())
+                    .medErAdopsjon(fagsystemBehandling.gjelderAdopsjon());
         }
         return hbSakBuilder.build();
     }

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/FagsystemKlient.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/FagsystemKlient.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.tilbakekreving.fagsystem.klient;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,7 +11,9 @@ import no.nav.foreldrepenger.tilbakekreving.fagsystem.klient.dto.TilbakekrevingV
 
 public interface FagsystemKlient {
 
-    boolean finnesBehandlingIFagsystem(String saksnummer, Henvisning henvisning);
+    default boolean finnesBehandlingIFagsystem(String saksnummer, Henvisning henvisning) {
+        return hentBehandlingForSaksnummerHenvisning(saksnummer, henvisning).isPresent();
+    }
 
     SamletEksternBehandlingInfo hentBehandlingsinfo(UUID eksternUuid, Tillegsinformasjon... tillegsinformasjon);
 
@@ -24,7 +25,7 @@ public interface FagsystemKlient {
 
     Optional<TilbakekrevingValgDto> hentTilbakekrevingValg(UUID eksternUuid);
 
-    List<EksternBehandlingsinfoDto> hentBehandlingForSaksnummer(String saksnummer);
+    Optional<EksternBehandlingsinfoDto> hentBehandlingForSaksnummerHenvisning(String saksnummer, Henvisning henvisning);
 
     FeilutbetaltePerioderDto hentFeilutbetaltePerioder(Henvisning henvisning);
 

--- a/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SamletEksternBehandlingInfo.java
+++ b/integrasjontjenester/fagsystem-klient-api/src/main/java/no/nav/foreldrepenger/tilbakekreving/fagsystem/klient/dto/SamletEksternBehandlingInfo.java
@@ -70,8 +70,12 @@ public class SamletEksternBehandlingInfo {
         return new AktørId(aktoerId);
     }
 
-    public SøknadType getSøknadType() {
-        return getSøknad().getSøknadType();
+    public boolean gjelderFødsel() {
+        return SøknadType.FØDSEL.equals(getSøknad().getSøknadType());
+    }
+
+    public boolean gjelderAdopsjon() {
+        return SøknadType.ADOPSJON.equals(getSøknad().getSøknadType());
     }
 
     public Saksnummer getSaksnummer() {

--- a/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlient.java
+++ b/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/FpsakKlient.java
@@ -58,16 +58,6 @@ public class FpsakKlient implements FagsystemKlient {
     }
 
     @Override
-    public boolean finnesBehandlingIFagsystem(String saksnummer, Henvisning henvisning) {
-        var eksternBehandlinger = hentBehandlingForSaksnummer(saksnummer);
-        if (!eksternBehandlinger.isEmpty()) {
-            return eksternBehandlinger.stream()
-                    .anyMatch(eksternBehandlingsinfoDto -> henvisning.equals(eksternBehandlingsinfoDto.getHenvisning()));
-        }
-        return false;
-    }
-
-    @Override
     public SamletEksternBehandlingInfo hentBehandlingsinfo(UUID eksternUuid, Tillegsinformasjon... tillegsinformasjon) {
         return hentBehandlingsinfoOpt(eksternUuid, Arrays.asList(tillegsinformasjon))
                 .orElseThrow(() -> new IntegrasjonException("FPT-841932", String.format("Fant ikke behandling med behandingUuid %s i fpsak", eksternUuid)));
@@ -148,8 +138,10 @@ public class FpsakKlient implements FagsystemKlient {
 
 
     @Override
-    public List<EksternBehandlingsinfoDto> hentBehandlingForSaksnummer(String saksnummer) {
-        return new ArrayList<>(hentFpsakBehandlingForSaksnummer(saksnummer));
+    public Optional<EksternBehandlingsinfoDto> hentBehandlingForSaksnummerHenvisning(String saksnummer, Henvisning henvisning) {
+        return new ArrayList<EksternBehandlingsinfoDto>(hentFpsakBehandlingForSaksnummer(saksnummer)).stream()
+            .filter(b -> henvisning.equals(b.getHenvisning()))
+            .findFirst();
     }
 
     @Override

--- a/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/dto/FpsakBehandlingFullDto.java
+++ b/integrasjontjenester/fpsak-klient/src/main/java/no/nav/foreldrepenger/tilbakekreving/fpsak/klient/dto/FpsakBehandlingFullDto.java
@@ -1,0 +1,41 @@
+package no.nav.foreldrepenger.tilbakekreving.fpsak.klient.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record FpsakBehandlingFullDto(@NotNull FpsakBehandlingDto behandling,
+                                     @NotNull FpsakFagsakDto fagsak,
+                                     @NotNull FamilieHendelseDto familieHendelse,
+                                     String varseltekst,
+                                     FeilutbetalingValg feilutbetalingValg,
+                                     Boolean sendtoppdrag,
+                                     FpsakVergeDto verge) {
+
+    public enum YtelseType { FORELDREPENGER, SVANGERSKAPSPENGER, ENGANGSSTØNAD }
+
+    public enum FamilieHendelseType { FØDSEL, ADOPSJON }
+
+    public enum VergeType { BARN, FORELDRELØS, VOKSEN, ADVOKAT, FULLMEKTIG }
+
+    public enum FeilutbetalingValg { OPPRETT, OPPDATER, IGNORER, INNTREKK }
+
+    public enum Språkkode { NB, NN, EN }
+
+    public record FpsakBehandlingDto(@NotNull UUID uuid, @NotNull HenvisningDto henvisning,
+                                     String behandlendeEnhetId, String behandlendeEnhetNavn,
+                                     Språkkode språkkode, LocalDate vedtaksdato) {}
+
+    public record FamilieHendelseDto(@NotNull FamilieHendelseType familieHendelseType, @NotNull Integer antallBarn) {}
+
+    public record FpsakFagsakDto(@NotNull String aktørId, @NotNull String saksnummer, @NotNull YtelseType fagsakYtelseType) { }
+
+    public record HenvisningDto(@NotNull @Min(0) @Max(Long.MAX_VALUE)Long henvisning) { }
+
+    public record FpsakVergeDto(@NotNull VergeType vergeType, String aktørId, String navn, String fnr,
+                                @NotNull LocalDate gyldigFom, @NotNull LocalDate gyldigTom, String organisasjonsnummer) { }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/HentKorrigertKravgrunnlagTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilbakekreving/web/app/tjenester/forvaltning/HentKorrigertKravgrunnlagTask.java
@@ -1,8 +1,6 @@
 package no.nav.foreldrepenger.tilbakekreving.web.app.tjenester.forvaltning;
 
 import java.math.BigInteger;
-import java.util.List;
-import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -104,14 +102,9 @@ public class HentKorrigertKravgrunnlagTask implements ProsessTaskHandler {
     //TODO k9-tilbake flytt til saksbehandlingKlient-er
     private EksternBehandlingsinfoDto hentEksternBehandlingFraFpsak(Behandling behandling, Henvisning henvisning) {
         String saksnummer = behandling.getFagsak().getSaksnummer().getVerdi();
-        List<EksternBehandlingsinfoDto> eksternBehandlinger = fagsystemKlient.hentBehandlingForSaksnummer(saksnummer);
-        Optional<EksternBehandlingsinfoDto> eksternBehandling = eksternBehandlinger.stream()
-                .filter(eksternBehandlingsinfoDto -> eksternBehandlingsinfoDto.getHenvisning().equals(henvisning)).findAny();
-        if (eksternBehandling.isEmpty()) {
-            throw new TekniskException("FPT-587197",
-                    String.format("Hentet et kravgrunnlag fra Økonomi for en behandling som ikke finnes i fpsak. behandlingId=%s, henvisningId=%s. Kravgrunnlaget skulle kanskje til et annet system. Si i fra til Økonomi!", behandling.getId(), henvisning.getVerdi()));
-        }
-        return eksternBehandling.get();
+        return fagsystemKlient.hentBehandlingForSaksnummerHenvisning(saksnummer, henvisning)
+            .orElseThrow(() -> new TekniskException("FPT-587197",
+                    String.format("Hentet et kravgrunnlag fra Økonomi for en behandling som ikke finnes i fpsak. behandlingId=%s, henvisningId=%s. Kravgrunnlaget skulle kanskje til et annet system. Si i fra til Økonomi!", behandling.getId(), henvisning.getVerdi())));
     }
 
     private void oppdaterEksternBehandling(Behandling behandling, EksternBehandlingsinfoDto eksternBehandlingsinfoDto) {


### PR DESCRIPTION
Samle metode som finner rett behandling for henvisning ved en hentalle+stream - henvisning som parameter.

Dto som kan tilbys av fpsak for å ta med all nødvendig info til brev mm i ett kall - exit ressurslenker.
* Trenger 2 endepunkt UUID og Saksnummer + Henvisning
* Lag Dto som vist her, uten ressurslenker.
* Skriv om FpsakKlient til å mappe fra Dto til SamletEksternBehandlingInfo