### PR TITLE
Legg til sif-code-scan i CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,3 +189,9 @@ jobs:
       namespace: k9saksbehandling
     secrets: inherit
 
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,5 +193,6 @@ jobs:
   sif-code-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,5 +194,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1
 

--- a/web/src/test/resources/xacml/xacmlresponse_1deny_1permit.json
+++ b/web/src/test/resources/xacml/xacmlresponse_1deny_1permit.json
@@ -61,7 +61,7 @@
           },
           {
             "AttributeId": "no.nav.abac.attributter.resource.felles.person.fnr",
-            "Value": "07078515206",
+            "Value": "15490357286",
             "Category": "urn:oasis:names:tc:xacml:3.0:attribute-category:resource",
             "DataType": "http://www.w3.org/2001/XMLSchema#string"
           }


### PR DESCRIPTION
Legger til sif-code-scan som en parallell jobb i CI-workflowen. Denne sjekker koden for sensitive data som fødselsnummer.