### PR TITLE
TFP-6978 bruk kvittertdato for avstemmingsliste

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/iverksetting/OppdragIverksettingStatusRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/iverksetting/OppdragIverksettingStatusRepository.java
@@ -67,8 +67,9 @@ public class OppdragIverksettingStatusRepository {
     public List<OppdragIverksettingStatusEntitet> finnForDato(LocalDate dato){
         var query = entityManager.createQuery("""
         from OppdragIverksettingStatus
-        where opprettetTidspunkt >= :t0
-        and opprettetTidspunkt < :t1
+        where kvittertTidspunkt is not null
+        and kvittertTidspunkt >= :t0
+        and kvittertTidspunkt < :t1
         order by opprettetTidspunkt desc""", OppdragIverksettingStatusEntitet.class);
         query.setParameter("t0", dato.atStartOfDay());
         query.setParameter("t1", dato.plusDays(1).atStartOfDay());

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/SendVedtakTilOppdragsystemetTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/SendVedtakTilOppdragsystemetTask.java
@@ -11,7 +11,6 @@ import no.nav.foreldrepenger.kontrakter.fpwsproxy.tilbakekreving.iverksett.Tilba
 import no.nav.foreldrepenger.tilbakekreving.behandling.beregning.BeregningsresultatTjeneste;
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.UkjentKvitteringFraOSException;
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.ØkonomiProxyKlient;
-import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.iverksetting.OppdragIverksettingStatusRepository;
@@ -60,7 +59,6 @@ public class SendVedtakTilOppdragsystemetTask implements ProsessTaskHandler {
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
         long behandlingId = ProsessTaskDataWrapper.wrap(prosessTaskData).getBehandlingId();
-        Behandling behandling = behandlingRepository.hentBehandling(behandlingId);
         beregningsresultatTjeneste.beregnOgLagre(behandlingId); //midlertidig her for å raskere kunne fase ut håndtering av lagret XML
         var tilbakekrevingsvedtak = tilbakekrevingsvedtakTjeneste.lagTilbakekrevingsvedtak(behandlingId);
         oppdragIverksettingStatusRepository.registrerStarterIverksetting(behandlingId, tilbakekrevingsvedtak.vedtakId().toString());
@@ -76,6 +74,7 @@ public class SendVedtakTilOppdragsystemetTask implements ProsessTaskHandler {
                 LOG.info("Tilbakekrevingsvedtak sendt OK til oppdragsystemet via fpwsproxy. BehandlingId={}", behandlingId);
                 oppdragIverksettingStatusRepository.registrerKvittering(behandlingId, true);
             } catch (UkjentKvitteringFraOSException e) {
+                // Er oversendt men mottatt negativ kvittering - kode 08 eller 16
                 oppdragIverksettingStatusRepository.registrerKvittering(behandlingId, false);
                 var rwsp = new RunWithSavepoint(entityManager);
                 rwsp.doWork(() -> {
@@ -84,6 +83,7 @@ public class SendVedtakTilOppdragsystemetTask implements ProsessTaskHandler {
                     throw new IntegrasjonException("FPT-609912", String.format("Fikk feil fra OS ved iverksetting av behandlingId=%s. Sjekk loggen til fpwsproxy for mer info.", behandlingId));
                 });
             }
+            // Feilet oversendelse - setter ikke kvitteringstidspunkt
             return null;
         });
     }


### PR DESCRIPTION
Hei, her er noe vi observerte både ifm OS-nedetid i vinter og et vedtak fattet 17/5 - begge tilfelle ville gi avvik ved avstemming av våre vedtak og OS sine mottatte vedtak.

SendVedtakTilOppdragsystemetTask lagrer en OppdragIverksettingStatusEntitet når den første gang sender vedtaket og dersom slik entitet finnes fra før så beholdes den (med tidligste opprettetTidspunkt). Så gjør den noen savepoint-tricks for å lagre kvitteringsTidspunkt - ved OK kvittering og ved negativ kvittering. Ved nedetid kommer en IntegrasjonsException som ikke fanges i SendVedtakTilOppdragsystemetTask så blir iverksettelsesentiteten liggende uten kvitteringstidspunkt

Logikken i AvstemFraResultatOgIverksettingStatusTjeneste henter vedtak opprettet en gitt dato. Den sjekker om det finnes positiv kvittering og tar dermed ikke med vedtakene som har feilet ved oversendelse. Når oversendelse går bra neste morgen, så gjør utplukket basert på opprettetTid at vedtaket aldri blir sendt til avstemming. 

Denne endringen vil plukke vedtak der OS har kvittert. Hvis det kommer 08/16 så sendes ikke vedtaket til avstemming, men dersom vi får rettet opp feilen så vil den bli forsøkt på nytt og får nytt kvitteringstidspunkt og blir da med i avstemming.

Jeg mener dette skal dekke alle tilfellene og sikre at OS og vi finner samme vedtak for en gitt dag. Men se gjerne gjennom.