### PR TITLE
TFP-6978 forenkle vedtakskvittering. Bare lagre ved positivt svar, feil ellers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,89 @@
+# fptilbake
+
+Tilbakekrevingsapplikasjon — handles cases where Nav has paid benefits to a
+client and the client must repay an amount (tilbakekreving + tilbakebetaling).
+
+Repository builds **two deployments** from the same codebase:
+- **fptilbake** — for Foreldrepenger, Svangerskapspenger, Engangsstønad (Team Foreldrepenger)
+- **k9-tilbake** — for k9-ytelser: pleiepenger, omsorgspenger, opplæringspenger, frisinn (Team Sykdom-i-familien)
+
+When changing code, consider impact on **both** deployments.
+
+## Domain
+
+| Concept | Description |
+|---------|-------------|
+| Kravgrunnlag | Trigger from payment system (oppdragssystem) with claim basis — the main entry point |
+| Varsel | Early notice letter sent when simulation indicates potential tilbakekreving |
+| Tilbakekrevingsbehandling | Case processing of the repayment claim |
+| Vurder vilkår | Evaluate cause and degree of client fault (forsett, grov uaktsomhet, simpel uaktsomhet) |
+| Vurder foreldelse | Evaluate statute of limitations |
+| Beregning | Calculate amount, tax (skattetrekk), and interest (rente) |
+| Vedtak | Decision letter (vedtaksbrev) to client + structured data to payment system |
+
+## Value chain position
+
+OS (Oppdragssystemet, payment system) is external to the team and handles the payment balance for the clients.
+The process is primarily triggered by a claim basis (kravgrunnlag) from OS over JMS/MQ, with a secondary entry point through varsel.
+The final decision (vedtak) is sent back to OS for balance adjustment and client communication, via fp-ws-proxy.
+
+```
+OS → kravgrunnlag over MQ → fptilbake/k9-tilbake → vedtak → iverksetting (Vedtak til OS via fp-ws-proxy, vedtaksbrev) 
+fpsak/k9-sak → simulerings -> varsel → fptilbake/k9-tilbake (opprett tilbakekreving, evt sender varsel)
+```
+
+## Tech stack
+
+Standard Team Foreldrepenger backend stack. See
+[fp-context/architecture/backend-stack.md](https://github.com/navikt/fp-context/blob/main/architecture/backend-stack.md).
+Java 25, Jetty, Jersey, Weld, Hibernate, Jackson, fp-prosesstask, fp-felles.
+
+## Module structure
+
+| Module | Purpose |
+|--------|---------|
+| `behandlingslager` | JPA entities, repositories |
+| `behandlingskontroll` | Behandlingssteg framework, aksjonspunkt orchestration |
+| `behandlingsprosess` | Concrete steg implementations (vilkår, foreldelse, beregning) |
+| `domenetjenester` | Domain services |
+| `integrasjontjenester` | External integrations (fpsak, fpoppdrag, k9-sak, k9-oppdrag) |
+| `kafka` | Kafka consumers/producers (kravgrunnlag, hendelser) |
+| `kontrakter` | API contracts |
+| `migreringer` | Flyway DB migrations |
+| `web` | REST endpoints, app entry point |
+| `testutilities` | Shared test fixtures |
+
+## Build and test
+
+```bash
+mvn clean install                                  # full build + unit tests
+mvn test -pl behandlingsprosess                    # tests for one module
+```
+
+## Integration tests
+
+Run from [fp-autotest](https://github.com/navikt/fp-autotest) (Foreldrepenger side):
+- Suite: `fptilbake` (also runs in `verdikjede`)
+- See `fp-autotest/AGENTS.md` for catalog and run commands
+
+k9-tilbake has its own integration test setup outside fp-autotest.
+
+## Team context
+
+| Hub                                                            | Purpose                                               |
+|----------------------------------------------------------------|-------------------------------------------------------|
+| [fp-context](https://github.com/navikt/fp-context)             | Team Foreldrepenger domain, architecture, conventions |
+| TeamForeldrepenger Copilot Space (`navikt`)                    | Same content, attached for AI grounding               |
+| [fp-gha-workflows](https://github.com/navikt/fp-gha-workflows) | Reusable CI/CD workflows                              |
+| [fp-bom](https://github.com/navikt/fp-bom)                     | Parent POM, dependency versions                       |
+| [fp-felles](https://github.com/navikt/fp-felles)               | Common components                                     |
+| [fp-prosesstask](https://github.com/navikt/fp-prosesstask)     | Asynch execution framework                            |
+
+Use these as authoritative for shared conventions. This file only covers
+fptilbake-specific information.
+
+## Cross-team note
+
+Changes here affect both Team Foreldrepenger and Team Sykdom-i-familien
+(`#sykdom-i-familien`, `#po-familie-tilbake`). Coordinate larger changes
+across teams.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,8 +29,11 @@ The final decision (vedtak) is sent back to OS for balance adjustment and client
 
 ```
 OS → kravgrunnlag over MQ → fptilbake/k9-tilbake → vedtak → iverksetting (Vedtak til OS via fp-ws-proxy, vedtaksbrev) 
-fpsak/k9-sak → simulerings -> varsel → fptilbake/k9-tilbake (opprett tilbakekreving, evt sender varsel)
+fpsak/k9-sak → simulering -> varsel → fptilbake/k9-tilbake (opprett tilbakekreving, evt sender varsel)
 ```
+
+fpoppdrag is **not** the source of kravgrunnlag — that comes directly from OS.
+fptilbake calls fpoppdrag only during the notice flow, to fetch repayment periods from the simulation as part of the notice letter.
 
 ## Tech stack
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/iverksetting/OppdragIverksettingStatusRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandlingslager/iverksetting/OppdragIverksettingStatusRepository.java
@@ -9,15 +9,10 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.vedtak.felles.jpa.HibernateVerktøy;
 
 @Dependent
 public class OppdragIverksettingStatusRepository {
-
-    private static final Logger LOG = LoggerFactory.getLogger(OppdragIverksettingStatusRepository.class);
 
     private EntityManager entityManager;
 
@@ -26,31 +21,11 @@ public class OppdragIverksettingStatusRepository {
         this.entityManager = entityManager;
     }
 
-    public void registrerStarterIverksetting(Long behandlingId, String vedtakId) {
-        var eksisterende = hentOppdragIverksettingStatus(behandlingId);
-        if (eksisterende.isPresent()) {
-            //skjer hvis prosesstask for iverksetting rekjøres
-            LOG.info("Har allerede registrert at iverksetting er startet");
-        } else {
-            entityManager.persist(new OppdragIverksettingStatusEntitet(behandlingId, vedtakId));
-        }
-    }
-
-    public void registrerKvittering(Long behandlingId, boolean kvitteringOk) {
-        registrerKvittering(behandlingId, LocalDateTime.now(), kvitteringOk);
-    }
-
-    private void registrerKvittering(Long behandlingId, LocalDateTime tidspunkt, boolean kvitteringOk) {
-        var eksisterende = hentOppdragIverksettingStatus(behandlingId);
-        if (eksisterende.isEmpty()) {
-            throw new IllegalStateException("Kan ikke oppdatere " + OppdragIverksettingStatusEntitet.class + " for behandling " + behandlingId + " siden det ikke finnes noen slik fra før");
-        }
-        if (Boolean.TRUE.equals(eksisterende.get().getKvitteringOk())) {
-            throw new IllegalStateException("Har allerede mottatt positiv kvittering for behandlingId=" + behandlingId);
-        }
-        var status = eksisterende.get();
-        status.registrerKvittering(tidspunkt, kvitteringOk);
-        entityManager.persist(status);
+    public void registrerKvittertVedtak(Long behandlingId, String vedtakId) {
+        var kvittering = hentOppdragIverksettingStatus(behandlingId).orElseGet(() -> new OppdragIverksettingStatusEntitet(behandlingId, vedtakId));
+        kvittering.registrerKvittering(LocalDateTime.now(), true);
+        entityManager.persist(kvittering);
+        entityManager.flush();
     }
 
     public Optional<OppdragIverksettingStatusEntitet> hentOppdragIverksettingStatus(Long behandlingId) {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/SendVedtakTilOppdragsystemetTask.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/SendVedtakTilOppdragsystemetTask.java
@@ -2,23 +2,16 @@ package no.nav.foreldrepenger.tilbakekreving.behandling.steg.iverksettvedtak;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.foreldrepenger.kontrakter.fpwsproxy.tilbakekreving.iverksett.TilbakekrevingVedtakDTO;
 import no.nav.foreldrepenger.tilbakekreving.behandling.beregning.BeregningsresultatTjeneste;
-import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.UkjentKvitteringFraOSException;
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.ØkonomiProxyKlient;
-import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.iverksetting.OppdragIverksettingStatusRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.task.ProsessTaskDataWrapper;
 import no.nav.foreldrepenger.tilbakekreving.iverksettevedtak.tjeneste.TilbakekrevingsvedtakTjeneste;
-import no.nav.vedtak.exception.IntegrasjonException;
-import no.nav.vedtak.felles.jpa.savepoint.RunWithSavepoint;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
@@ -30,8 +23,6 @@ public class SendVedtakTilOppdragsystemetTask implements ProsessTaskHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(SendVedtakTilOppdragsystemetTask.class);
 
-    private EntityManager entityManager;
-    private BehandlingRepository behandlingRepository;
     private OppdragIverksettingStatusRepository oppdragIverksettingStatusRepository;
     private TilbakekrevingsvedtakTjeneste tilbakekrevingsvedtakTjeneste;
     private BeregningsresultatTjeneste beregningsresultatTjeneste;
@@ -43,14 +34,10 @@ public class SendVedtakTilOppdragsystemetTask implements ProsessTaskHandler {
     }
 
     @Inject
-    public SendVedtakTilOppdragsystemetTask(EntityManager entityManager,
-                                            BehandlingRepository behandlingRepository,
-                                            OppdragIverksettingStatusRepository oppdragIverksettingStatusRepository,
+    public SendVedtakTilOppdragsystemetTask(OppdragIverksettingStatusRepository oppdragIverksettingStatusRepository,
                                             BeregningsresultatTjeneste beregningsresultatTjeneste,
                                             TilbakekrevingsvedtakTjeneste tilbakekrevingsvedtakTjeneste,
                                             ØkonomiProxyKlient økonomiProxyKlient) {
-        this.entityManager = entityManager;
-        this.behandlingRepository = behandlingRepository;
         this.oppdragIverksettingStatusRepository = oppdragIverksettingStatusRepository;
         this.beregningsresultatTjeneste = beregningsresultatTjeneste;
         this.tilbakekrevingsvedtakTjeneste = tilbakekrevingsvedtakTjeneste;
@@ -60,31 +47,11 @@ public class SendVedtakTilOppdragsystemetTask implements ProsessTaskHandler {
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
         long behandlingId = ProsessTaskDataWrapper.wrap(prosessTaskData).getBehandlingId();
-        Behandling behandling = behandlingRepository.hentBehandling(behandlingId);
         beregningsresultatTjeneste.beregnOgLagre(behandlingId); //midlertidig her for å raskere kunne fase ut håndtering av lagret XML
         var tilbakekrevingsvedtak = tilbakekrevingsvedtakTjeneste.lagTilbakekrevingsvedtak(behandlingId);
-        oppdragIverksettingStatusRepository.registrerStarterIverksetting(behandlingId, tilbakekrevingsvedtak.vedtakId().toString());
-        lagSavepointOgIverksettViaFpWsProxy(behandlingId, tilbakekrevingsvedtak);
+        økonomiProxyKlient.iverksettTilbakekrevingsvedtak(tilbakekrevingsvedtak);
+        LOG.info("Tilbakekrevingsvedtak sendt OK til oppdragsystemet via fpwsproxy. BehandlingId={}", behandlingId);
+        oppdragIverksettingStatusRepository.registrerKvittertVedtak(behandlingId, tilbakekrevingsvedtak.vedtakId().toString());
     }
 
-    private void lagSavepointOgIverksettViaFpWsProxy(long behandlingId, TilbakekrevingVedtakDTO tilbakekrevingsvedtak) {
-        var runWithSavepoint = new RunWithSavepoint(entityManager);
-        runWithSavepoint.doWork(() -> {
-            //setter før kall til OS, slik at kvittering-status blir lagret selv om kallet feiler
-            try {
-                økonomiProxyKlient.iverksettTilbakekrevingsvedtak(tilbakekrevingsvedtak);
-                LOG.info("Tilbakekrevingsvedtak sendt OK til oppdragsystemet via fpwsproxy. BehandlingId={}", behandlingId);
-                oppdragIverksettingStatusRepository.registrerKvittering(behandlingId, true);
-            } catch (UkjentKvitteringFraOSException e) {
-                oppdragIverksettingStatusRepository.registrerKvittering(behandlingId, false);
-                var rwsp = new RunWithSavepoint(entityManager);
-                rwsp.doWork(() -> {
-                    // Kaster feil for å feile prosesstasken, samt trigge logging.
-                    // Setter savepoint før feilen kastes, slik at kvittering-status blir lagret, selv om det blir exception
-                    throw new IntegrasjonException("FPT-609912", String.format("Fikk feil fra OS ved iverksetting av behandlingId=%s. Sjekk loggen til fpwsproxy for mer info.", behandlingId));
-                });
-            }
-            return null;
-        });
-    }
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/SendVedtakTilOppdragsystemetTaskTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/tilbakekreving/behandling/steg/iverksettvedtak/SendVedtakTilOppdragsystemetTaskTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,6 @@ import no.nav.foreldrepenger.tilbakekreving.behandling.beregning.Beregningsresul
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.UkjentKvitteringFraOSException;
 import no.nav.foreldrepenger.tilbakekreving.behandling.steg.hentgrunnlag.fpwsproxy.ØkonomiProxyKlient;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.iverksetting.OppdragIverksettingStatusRepository;
 import no.nav.foreldrepenger.tilbakekreving.behandlingslager.testutilities.kodeverk.ScenarioSimple;
@@ -31,10 +29,6 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 @CdiDbAwareTest
 class SendVedtakTilOppdragsystemetTaskTest {
 
-    @Inject
-    private EntityManager entityManager;
-    @Inject
-    private BehandlingRepository behandlingRepository;
     @Inject
     private BehandlingRepositoryProvider behandlingRepositoryProvider;
     @Inject
@@ -50,7 +44,7 @@ class SendVedtakTilOppdragsystemetTaskTest {
 
     @BeforeEach
     void setup() {
-        task = new SendVedtakTilOppdragsystemetTask(entityManager, behandlingRepository, oppdragIverksettingStatusRepository, beregningsresultatTjeneste, tilbakekrevingsvedtakTjeneste, økonomiProxyKlient);
+        task = new SendVedtakTilOppdragsystemetTask(oppdragIverksettingStatusRepository, beregningsresultatTjeneste, tilbakekrevingsvedtakTjeneste, økonomiProxyKlient);
     }
 
     @Test
@@ -76,7 +70,7 @@ class SendVedtakTilOppdragsystemetTaskTest {
 
     @Test
     void skal_få_exception_når_kvittering_ikke_er_OK() {
-        doThrow(new UkjentKvitteringFraOSException("FPT-539080", "Fikk feil fra OS ved iverksetting av tilbakekrevginsvedtak. Sjekk loggen til fpwsproxy for mer info."))
+        doThrow(new UkjentKvitteringFraOSException("FPT-539080", "Fikk feil fra OS ved iverksetting av tilbakekrevingsvedtak. Sjekk loggen til fpwsproxy for mer info."))
             .when(økonomiProxyKlient).iverksettTilbakekrevingsvedtak(any());
 
         var scenario = ScenarioSimple
@@ -86,11 +80,10 @@ class SendVedtakTilOppdragsystemetTaskTest {
         var behandling = scenario.lagre(behandlingRepositoryProvider);
         var data = lagProsessTaskKonfigurasjon(behandling);
 
-        assertThatThrownBy(() -> task.doTask(data)).hasMessageContaining("Fikk feil fra OS ved iverksetting av behandling");
-        //har lagret status riktig
+        assertThatThrownBy(() -> task.doTask(data)).hasMessageContaining("Fikk feil fra OS ved iverksetting av tilbakekrevingsvedtak");
+        //har ikke lagret status
         var status = oppdragIverksettingStatusRepository.hentOppdragIverksettingStatus(behandling.getId());
-        assertThat(status).isPresent();
-        assertThat(status.get().getKvitteringOk()).isFalse();
+        assertThat(status).isEmpty();
     }
 
     private ProsessTaskData lagProsessTaskKonfigurasjon(Behandling behandling) {

--- a/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/avstemming/AvstemFraResultatOgIverksettingStatusTjeneste.java
+++ b/domenetjenester/src/main/java/no/nav/foreldrepenger/tilbakekreving/avstemming/AvstemFraResultatOgIverksettingStatusTjeneste.java
@@ -72,14 +72,9 @@ public class AvstemFraResultatOgIverksettingStatusTjeneste {
     }
 
     public void leggTilOppsummering(LocalDate dato, AvstemmingCsvFormatter avstemmingCsvFormatter) {
-        var antallFeilet = 0;
         var antallFørstegangsvedtakUtenTilbakekreving = 0;
         var iverksettingStatuser = oppdragIverksettingStatusRepository.finnForDato(dato);
         for (var iverksettingStatus : iverksettingStatuser) {
-            if (!iverksettingStatus.getKvitteringOk()) {
-                antallFeilet++;
-                continue;
-            }
             var behandlingId = iverksettingStatus.getBehandlingId();
             var behandling = behandlingRepository.hentBehandling(behandlingId);
             var beregningsresultat = beregningsresultatRepository.hentHvisEksisterer(behandlingId).orElseThrow();
@@ -90,9 +85,6 @@ public class AvstemFraResultatOgIverksettingStatusTjeneste {
             }
             leggTilAvstemmingsdataForVedtaket(avstemmingCsvFormatter, behandling, oppsummering);
 
-        }
-        if (antallFeilet != 0) {
-            LOG.warn("{} vedtak har feilet i overføring til OS for {}", antallFeilet, dato);
         }
         if (antallFørstegangsvedtakUtenTilbakekreving != 0) {
             LOG.info("{} førstegangsvedtak uten tilbakekreving sendes ikke til avstemming for {}", antallFørstegangsvedtakUtenTilbakekreving, dato);


### PR DESCRIPTION
Denne vil også løse avstemmingsproblemet ved nedetid eller negativ kvittering. 
Jeg mistenker at kravgrunnlagene sperres allerede når vi simulerer en revurdering. Skal høre med økonomi.