### PR TITLE
TFP-6363: eksplisitte secrets og rett-dimensjonerte permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,12 @@ jobs:
     name: Build
     permissions:
       contents: read
-      packages: write
+      packages: read
       id-token: write
     uses: navikt/fp-gha-workflows/.github/workflows/build-app-no-db.yml@main
     with:
       build-image: ${{ github.ref_name == 'master' }} # default: true
       push-image: ${{ github.ref_name == 'master' }} # default: false
-    secrets: inherit
 
   typescript-client:
     name: Build typescript client
@@ -95,7 +94,6 @@ jobs:
     with:
       build-version: ${{ needs.build-app.outputs.build-version }}
       test-suite: fptilbake
-    secrets: inherit
 
   verdikjede-tester:
     name: Verdikjedetester
@@ -108,7 +106,6 @@ jobs:
     with:
       build-version: ${{ needs.build-app.outputs.build-version }}
       test-suite: verdikjede
-    secrets: inherit
 
   k9-verdikjede-tester:
     name: K9 Verdikjedetester
@@ -135,7 +132,8 @@ jobs:
       fptilbake: ${{ needs.fptilbake-tester.outputs.resultat }}
       verdikjede: ${{ needs.verdikjede-tester.outputs.resultat }}
       build-version: ${{ needs.build-app.outputs.build-version }}
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy-dev-teamforeldrepenger:
     name: Deploy dev fp
@@ -148,7 +146,6 @@ jobs:
       image: ${{ needs.build-app.outputs.build-version }}
       cluster: dev-fss
       namespace: teamforeldrepenger
-    secrets: inherit
 
   deploy-prod-teamforeldrepenger:
     name: Deploy prod fp
@@ -161,7 +158,6 @@ jobs:
       image: ${{ needs.build-app.outputs.build-version }}
       cluster: prod-fss
       namespace: teamforeldrepenger
-    secrets: inherit
 
   deploy-dev-k9saksbehandling:
     name: Deploy dev k9

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,6 @@ jobs:
         uses: nais/login@40b72a35a18ddf2ad74b632461139ab838cc2a2f # ratchet:nais/login@v0
         id: login
         with:
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           team: ${{ inputs.namespace }}
 
       - name: Deploy ${{ inputs.cluster }} fra GAR


### PR DESCRIPTION
## Sammendrag
- Erstatter `secrets: inherit` med eksplisitte secrets (eller fjerner der ingen kreves) i **fp-jobbene**:
  - `build-app`: fjerner `inherit`; `packages: write` → `read` (matcher `build-app-no-db.yml`)
  - `fptilbake-tester` / `verdikjede-tester`: fjerner `inherit` (autotest bruker kun auto-`GITHUB_TOKEN`)
  - `notify`: eksplisitt `SLACK_WEBHOOK`
  - `deploy-dev/prod-teamforeldrepenger`: fjerner `inherit` (deploy trenger ingen passert secret)
- Fjerner **ubrukt** `NAIS_WORKLOAD_IDENTITY_PROVIDER` (og `project_id`) fra `nais/login` i `deploy.yml`. `nais/login` auto-oppdager provider/prosjekt, likt den delte `fp-gha-workflows/deploy.yml`.

## Urørt (k9 / Team Sykdom i familien)
`typescript-client`, `publish-image-k9`, `k9-verdikjede-tester`, `deploy-dev/prod-k9saksbehandling` og `sif-code-scan` er **ikke** endret og arver fortsatt via `secrets: inherit`. k9-tilbake-deployen påvirkes ikke.

## Validering
- `python3 -c "import yaml; yaml.safe_load(...)"` på `build.yml` og `deploy.yml` — OK
- Ingen `NAIS_WORKLOAD_IDENTITY_PROVIDER` gjenstår i `.github/`
- Gjenværende `secrets: inherit` er kun de fire k9-jobbene (verifisert)
