### PR TITLE
TFP-6363: eksplisitte secrets i codeql, deploy-manuelt og dependency-submission

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,4 +16,5 @@ jobs:
      contents: read
      security-events: write
    uses: navikt/fp-gha-workflows/.github/workflows/codeql.yml@main
-   secrets: inherit
+   secrets:
+     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/dependency-submisson.yml
+++ b/.github/workflows/dependency-submisson.yml
@@ -13,4 +13,3 @@ jobs:
     permissions:
       contents: write
     uses: navikt/fp-gha-workflows/.github/workflows/mvn-dependency-submission.yml@main
-    secrets: inherit

--- a/.github/workflows/deploy-manuelt.yml
+++ b/.github/workflows/deploy-manuelt.yml
@@ -31,4 +31,3 @@ jobs:
       image: ${{ inputs.image }}
       cluster: ${{ inputs.environment }}-fss
       namespace: ${{ inputs.namespace }}
-    secrets: inherit


### PR DESCRIPTION
## Sammendrag
- Fjerner `secrets: inherit` fra alle jobber i CI-workflowene og deklarerer kun de secretsene som faktisk brukes: `SONAR_TOKEN` til CodeQL og (der det finnes) `SLACK_WEBHOOK` til notify-jobben. Øvrige jobber bruker innebygd `GITHUB_TOKEN` via `permissions`.
- Rett-dimensjonerer `permissions` mot kontraktene i de gjenbrukbare workflowene (fp-gha-workflows / fp-autotest), bl.a. `build-app`: `packages: write` → `read` og fjerner ubrukt `pull-requests: read` (image pushes til GAR via OIDC).
- Ledd i TFP-6363: fjerne langlivde PAT-er og gjøre CI-tilganger eksplisitte og minimale.

## Validering
- `python3 -c "yaml.safe_load_all(...)"` på alle endrede workflow-filer
- `zizmor --offline --persona=regular .github/workflows/` (kun by-design `unpinned-uses` på egne `@main`/`@master`-reusables)
- `grep -rn "inherit" .github/workflows/` → ingen treff
